### PR TITLE
chore(codeowners): require review for classifier anchor definitions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,11 @@
 # The wire contract, the specification record, and the architecture decisions
 # change the project's external commitments — always maintainer-reviewed.
 /proto/            @cnuland
+# Anchor definitions are behaviour, not data: they are compiled into the binary
+# via include_str! and their taxonomy_revision participates in the result cache
+# key, so a change here changes what the service returns and invalidates cached
+# classifications.
+/classifiers/      @cnuland
 /specs/            @cnuland
 /docs/decisions/   @cnuland
 /SECURITY.md       @cnuland


### PR DESCRIPTION
Small change ahead of onboarding contributors.

`classifiers/*.json` reads like configuration and is not. The definitions are
compiled into the binary via `include_str!`, and each one's `taxonomy_revision`
participates in the result cache key, so editing an anchor changes what the
service returns and invalidates previously cached classifications.

Adds an explicit CODEOWNERS entry so anchor changes are reviewed on the same
footing as `proto/` and `docs/decisions/`, rather than falling through to the
default owner by accident.

Raised as a PR rather than a push because `main` should be protected from here
on. See the note in the linked discussion about branch protection requiring an
admin.