### PR TITLE
chore(build): chef-style cached build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,21 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
+
+# Layer 1: copy manifests so dependency compilation is cacheable.
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src/bin \
+ && echo 'fn main() {}' > src/lib.rs \
+ && echo 'fn main() {}' > src/bin/server.rs \
+ && echo 'fn main() {}' > src/bin/classify.rs \
+ && echo 'fn main() {}' > src/bin/gateway-probe.rs \
+ && cargo build --release \
+        --bin llm-d-sc-server \
+        --bin llm-d-sc-classify \
+        --bin llm-d-sc-gateway-probe \
+ && rm -rf target/release/deps target/release/.fingerprint target/release/build
+
+# Layer 2: copy source; only the final build is incremental.
 COPY . .
 RUN cargo build --release \
       --bin llm-d-sc-server \


### PR DESCRIPTION
Adds an additional layer in front of the real build with 4 dummy entry points to populate the build cache.

```sh
 'fn main() {}' > src/lib.rs \
 'fn main() {}' > src/bin/server.rs \
 'fn main() {}' > src/bin/classify.rs \
 'fn main() {}' > src/bin/gateway-probe.rs \
```

Verified with:

```
❯ time podman build -t localhost/llm-d-sc:test -f Containerfile .
...
podman build -t localhost/llm-d-sc:test -f Containerfile .  0.07s user 0.08s system 0% cpu 2:28.27 total

❯ echo "// test" >> src/lib.rs
❯ time podman build -t localhost/llm-d-sc:test -f Containerfile .
...
podman build -t localhost/llm-d-sc:test -f Containerfile .  0.03s user 0.03s system 0% cpu 1:13.30 total

❯ echo "# test" >> Cargo.lock
❯ time podman build -t localhost/llm-d-sc:test -f Containerfile .
...
podman build -t localhost/llm-d-sc:test -f Containerfile .  0.03s user 0.03s system 0% cpu 1:14.08 total
```

Fixes #10 