### PR TITLE
fix: Coalesced-waiter hit-rate inflation

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -183,9 +183,11 @@ fn seeded_warm_context(cache_mode: CacheMode, seed: &str, run_id: u64, index: u6
 /// Miss-mode: every measured request must be a genuine miss, so
 /// `delta_misses == measured` and `delta_hits == 0`. Hit-mode: every measured
 /// request must be a genuine hit, so `delta_hits == measured` and
-/// `delta_misses == 0`. A violation (e.g. warmup/measured key collision after a
-/// refactor) returns a [`BenchError::Methodology`] instead of silently producing
-/// invalid benchmark numbers.
+/// `delta_misses == 0`. Both modes additionally require `delta_coalesced == 0`
+/// because serial measurement must never trigger single-flight coalescing. A
+/// violation (e.g. warmup/measured key collision after a refactor) returns a
+/// [`BenchError::Methodology`] instead of silently producing invalid benchmark
+/// numbers.
 fn verify_window(
     cache_mode: CacheMode,
     before: MetricsSnapshot,
@@ -194,6 +196,7 @@ fn verify_window(
 ) -> Result<(), BenchError> {
     let delta_hits = after.cache_hits.saturating_sub(before.cache_hits);
     let delta_misses = after.cache_misses.saturating_sub(before.cache_misses);
+    let delta_coalesced = after.cache_coalesced.saturating_sub(before.cache_coalesced);
     match cache_mode {
         CacheMode::Miss => {
             if delta_misses != measured {
@@ -206,6 +209,11 @@ fn verify_window(
                     "miss-mode methodology violation: expected 0 cache hits in the measured window, observed delta_hits={delta_hits}"
                 )));
             }
+            if delta_coalesced != 0 {
+                return Err(BenchError::Methodology(format!(
+                    "miss-mode methodology violation: expected 0 coalesced waits in the measured window, observed delta_coalesced={delta_coalesced}; serial measurement must not coalesce"
+                )));
+            }
         }
         CacheMode::Hit => {
             if delta_hits != measured {
@@ -216,6 +224,11 @@ fn verify_window(
             if delta_misses != 0 {
                 return Err(BenchError::Methodology(format!(
                     "hit-mode methodology violation: expected 0 cache misses in the measured window, observed delta_misses={delta_misses}"
+                )));
+            }
+            if delta_coalesced != 0 {
+                return Err(BenchError::Methodology(format!(
+                    "hit-mode methodology violation: expected 0 coalesced waits in the measured window, observed delta_coalesced={delta_coalesced}; serial measurement must not coalesce"
                 )));
             }
         }
@@ -592,12 +605,9 @@ mod tests {
     /// A snapshot helper: a metrics snapshot with the given cache counters.
     fn snap(hits: u64, misses: u64) -> MetricsSnapshot {
         MetricsSnapshot {
-            queue: std::time::Duration::ZERO,
-            tokenize: std::time::Duration::ZERO,
-            forward: std::time::Duration::ZERO,
-            total: std::time::Duration::ZERO,
             cache_hits: hits,
             cache_misses: misses,
+            ..Default::default()
         }
     }
 
@@ -629,5 +639,28 @@ mod tests {
         let err = verify_window(CacheMode::Hit, snap(0, 0), snap(100, 900), 1000)
             .expect_err("a hit window with un-pre-warmed measured keys must fail");
         assert!(err.to_string().contains("hit-mode"));
+    }
+
+    /// Both modes reject unexpected coalesced waits: serial measurement must
+    /// never trigger single-flight coalescing.
+    #[test]
+    fn methodology_rejects_unexpected_coalescing() {
+        let coalesced_after = MetricsSnapshot {
+            cache_misses: 1000,
+            cache_coalesced: 1,
+            ..Default::default()
+        };
+        let err = verify_window(CacheMode::Miss, snap(0, 0), coalesced_after, 1000)
+            .expect_err("miss-mode must reject coalesced waits");
+        assert!(err.to_string().contains("coalesced"));
+
+        let coalesced_after = MetricsSnapshot {
+            cache_hits: 1000,
+            cache_coalesced: 1,
+            ..Default::default()
+        };
+        let err = verify_window(CacheMode::Hit, snap(0, 0), coalesced_after, 1000)
+            .expect_err("hit-mode must reject coalesced waits");
+        assert!(err.to_string().contains("coalesced"));
     }
 }

--- a/src/bin/bench-runner.rs
+++ b/src/bin/bench-runner.rs
@@ -262,6 +262,7 @@ fn stage_delta(before: MetricsSnapshot, after: MetricsSnapshot) -> MetricsSnapsh
         total: after.total.saturating_sub(before.total),
         cache_hits: after.cache_hits.saturating_sub(before.cache_hits),
         cache_misses: after.cache_misses.saturating_sub(before.cache_misses),
+        cache_coalesced: after.cache_coalesced.saturating_sub(before.cache_coalesced),
     }
 }
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -73,7 +73,7 @@ fn main() -> io::Result<()> {
             loop {
                 std::thread::sleep(std::time::Duration::from_secs(interval));
                 let snap = metrics.snapshot();
-                let served = snap.cache_hits + snap.cache_misses;
+                let served = snap.cache_hits + snap.cache_misses + snap.cache_coalesced;
                 if served == last_total {
                     continue;
                 }
@@ -84,11 +84,12 @@ fn main() -> io::Result<()> {
                 let f = stage(LatencyStage::Forward);
                 let tot = stage(LatencyStage::Total);
                 eprintln!(
-                    "llm-d-sc metrics: served={served} hits={} misses={} | \
+                    "llm-d-sc metrics: served={served} hits={} misses={} coalesced={} | \
                      queue p50={:?} p99={:?} | tokenize p50={:?} p99={:?} | \
                      forward p50={:?} p99={:?} | total p50={:?} p99={:?}",
                     snap.cache_hits,
                     snap.cache_misses,
+                    snap.cache_coalesced,
                     q.p50,
                     q.p99,
                     t.p50,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,6 +25,27 @@ use std::sync::{Arc, Condvar, Mutex};
 
 use crate::classify::{ClassificationResult, ClassifyError};
 
+/// The path a request took through the cache pipeline.
+///
+/// A cache interaction has three possible outcomes, each with distinct
+/// latency characteristics (AC-006/AC-007):
+///   - `Hit`:       result was already cached (~microseconds)
+///   - `Miss`:      ran the forward closure (tokenize + embed + rank)
+///   - `Coalesced`: waited for another thread's in-flight forward
+///
+/// The distinction matters for metrics accuracy: a coalesced wait
+/// experiences miss-class latency but was previously counted as a hit
+/// because no forward closure ran on that thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachePath {
+    /// Served from the exact-result cache (no forward, no wait).
+    Hit,
+    /// Ran the forward closure (designated single-flight forwarder).
+    Miss,
+    /// Waited for another thread's in-flight forward result.
+    Coalesced,
+}
+
 /// A versioned fingerprint cache key (design.md).
 ///
 /// The key is a 32-byte blake3 fingerprint over classifier/model/tokenizer/
@@ -270,24 +291,26 @@ impl SharedCache {
         }
     }
 
-    /// Classify `key` concurrently, returning the classification result.
+    /// Classify `key` concurrently, returning the classification result and
+    /// the [`CachePath`] that produced it.
     ///
-    /// Serves an already-cached result on the fast path. On a miss, the FIRST
-    /// caller for `key` runs the forward closure once (single-flight); every
-    /// other identical concurrent miss waits for and reads that shared result
-    /// instead of running its own forward. This bounds identical concurrent
+    /// Serves an already-cached result on the fast path (`CachePath::Hit`).
+    /// On a miss, the FIRST caller for `key` runs the forward closure once
+    /// (single-flight, `CachePath::Miss`); every other identical concurrent
+    /// miss waits for and reads that shared result instead of running its own
+    /// forward (`CachePath::Coalesced`). This bounds identical concurrent
     /// misses to ONE forward per distinct key (AC-007). A failed forward is
     /// propagated to every caller and is NOT cached.
     pub fn classify_concurrent(
         &self,
         key: CacheKey,
         forward: impl FnOnce() -> Result<ClassificationResult, ClassifyError>,
-    ) -> Result<ClassificationResult, ClassifyError> {
+    ) -> (Result<ClassificationResult, ClassifyError>, CachePath) {
         // Fast path: serve an already-cached result.
         {
             let inner = self.inner.lock().unwrap();
             if let Some(cached) = inner.cached_value(&key) {
-                return Ok(cached);
+                return (Ok(cached), CachePath::Hit);
             }
         }
         // Single-flight: if another thread is already forwarding this key, wait
@@ -311,7 +334,7 @@ impl SharedCache {
             while result.is_none() {
                 result = slot.condvar.wait(result).unwrap();
             }
-            return result.clone().unwrap();
+            return (result.clone().unwrap(), CachePath::Coalesced);
         }
         // We are the designated forwarder: run the forward exactly once.
         let result = forward();
@@ -328,7 +351,7 @@ impl SharedCache {
         *result_guard = Some(result.clone());
         drop(result_guard);
         slot.condvar.notify_all();
-        result
+        (result, CachePath::Miss)
     }
 
     /// Number of times the tokenizer/model forward was invoked (all threads).
@@ -419,7 +442,7 @@ mod bounded_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::{CacheKey, ExactCache, SharedCache};
+    use super::{CacheKey, CachePath, ExactCache, SharedCache};
     use crate::classify::{ClassificationResult, ClassifyError, ClassifyStatus, RankedSignal};
     use std::sync::{Arc, Barrier};
     use std::thread;
@@ -614,7 +637,7 @@ mod tests {
             }));
         }
 
-        let results: Vec<Result<ClassificationResult, ClassifyError>> =
+        let results: Vec<(Result<ClassificationResult, ClassifyError>, CachePath)> =
             handles.into_iter().map(|h| h.join().unwrap()).collect();
 
         assert_eq!(
@@ -626,8 +649,23 @@ mod tests {
         assert!(
             results
                 .iter()
-                .all(|r| matches!(r, Ok(c) if c.ranked.first().map(|s| s.id.as_str()) == Some("sensitivity"))),
+                .all(|r| matches!(&r.0, Ok(c) if c.ranked.first().map(|s| s.id.as_str()) == Some("sensitivity"))),
             "every concurrent caller must receive the same classification result"
         );
+        // Exactly one caller should be the designated forwarder (Miss), the
+        // rest waited for its result (Coalesced). None are Hits (cold cache).
+        let misses = results.iter().filter(|r| r.1 == CachePath::Miss).count();
+        let coalesced = results
+            .iter()
+            .filter(|r| r.1 == CachePath::Coalesced)
+            .count();
+        let hits = results.iter().filter(|r| r.1 == CachePath::Hit).count();
+        assert_eq!(misses, 1, "exactly one designated forwarder");
+        assert_eq!(
+            coalesced,
+            CONCURRENCY - 1,
+            "all other callers must be coalesced waits"
+        );
+        assert_eq!(hits, 0, "no true cache hits on a cold cache");
     }
 }

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -23,10 +23,10 @@
 //! [`ClassificationResult`], keyed by a blake3 versioned fingerprint.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::cache::{CacheKey, SharedCache};
+use crate::cache::{CacheKey, CachePath, SharedCache};
 use crate::metrics::{LatencyStage, Metrics};
 use crate::ranker::{anchor_rank, cosine_rank, AnchorSet, Prototype};
 use crate::taxonomy::ClassifierDefinition;
@@ -277,31 +277,20 @@ where
             &normalized,
         );
         let metrics = self.metrics.clone();
-        // A miss runs the raw backend forward on the designated single-flight
-        // caller; a hit bypasses it entirely (AC-006). The flag distinguishes the
-        // two so the hit/miss counters partition every request.
-        let forward_ran = Arc::new(AtomicBool::new(false));
         let forward = {
             let runtime = self.runtime.clone();
-            let metrics = metrics.clone();
-            let forward_ran = forward_ran.clone();
             let input = ClassificationInput {
                 text: normalized,
                 requested_signals: input.requested_signals,
                 session_metadata: input.session_metadata,
             };
-            move || {
-                forward_ran.store(true, Ordering::SeqCst);
-                let _ = &metrics;
-                runtime.classify(input)
-            }
+            move || runtime.classify(input)
         };
-        let result = self.cache.classify_concurrent(key, forward);
-        // Classify the request as a cache hit or miss and expose the counters.
-        if forward_ran.load(Ordering::SeqCst) {
-            metrics.record_cache_miss();
-        } else {
-            metrics.record_cache_hit();
+        let (result, path) = self.cache.classify_concurrent(key, forward);
+        match path {
+            CachePath::Hit => metrics.record_cache_hit(),
+            CachePath::Miss => metrics.record_cache_miss(),
+            CachePath::Coalesced => metrics.record_cache_coalesced(),
         }
         // Queue and Total are deliberately NOT recorded here. The executor owns
         // Queue (it is the only component that knows how long a job waited), and

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -139,6 +139,9 @@ pub struct MetricsSnapshot {
     pub cache_hits: u64,
     /// Number of classification requests that ran a real forward (cache miss).
     pub cache_misses: u64,
+    /// Number of classification requests that waited for another thread's
+    /// in-flight forward (single-flight coalesced, AC-007).
+    pub cache_coalesced: u64,
 }
 
 /// The shared latency/counter registry behind the metrics surface.
@@ -159,6 +162,7 @@ struct Inner {
     total: Duration,
     cache_hits: u64,
     cache_misses: u64,
+    cache_coalesced: u64,
     hist_queue: Histogram,
     hist_tokenize: Histogram,
     hist_forward: Histogram,
@@ -218,6 +222,13 @@ impl Metrics {
         self.inner.lock().unwrap().cache_misses += 1;
     }
 
+    /// Record one classification that waited for another thread's in-flight
+    /// forward (single-flight coalesced, AC-007). Previously counted as a
+    /// cache hit, but with miss-class latency.
+    pub fn record_cache_coalesced(&self) {
+        self.inner.lock().unwrap().cache_coalesced += 1;
+    }
+
     /// An immutable snapshot of the accumulated latency decomposition.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let inner = self.inner.lock().unwrap();
@@ -228,6 +239,7 @@ impl Metrics {
             total: inner.total,
             cache_hits: inner.cache_hits,
             cache_misses: inner.cache_misses,
+            cache_coalesced: inner.cache_coalesced,
         }
     }
 }
@@ -363,18 +375,25 @@ mod tests {
         assert!(snap.forward <= snap.total);
     }
 
-    /// U-081 (AC-012): cache hit/miss counters are counted independently and
-    /// partition every request exactly.
+    /// U-081 (AC-012): cache hit/miss/coalesced counters are counted
+    /// independently and partition every request exactly.
     #[test]
     fn u081_cache_hit_miss_counters_partition() {
         let metrics = Metrics::new();
         metrics.record_cache_hit();
         metrics.record_cache_hit();
         metrics.record_cache_miss();
+        metrics.record_cache_coalesced();
+        metrics.record_cache_coalesced();
+        metrics.record_cache_coalesced();
 
         let snap = metrics.snapshot();
         assert_eq!(snap.cache_hits, 2);
         assert_eq!(snap.cache_misses, 1);
-        assert_eq!(snap.cache_hits + snap.cache_misses, 3);
+        assert_eq!(snap.cache_coalesced, 3);
+        assert_eq!(
+            snap.cache_hits + snap.cache_misses + snap.cache_coalesced,
+            6
+        );
     }
 }

--- a/tests/TEST_MATRIX.md
+++ b/tests/TEST_MATRIX.md
@@ -32,7 +32,7 @@ Test IDs are evidence anchors. Each version's `test-plan.md` selects the require
 | U-035 | shutdown stops admission and drains configured in-flight work | 0.20 |
 | U-036 | one runtime error cannot poison unrelated requests | 0.20 |
 | U-040 | exact cache hit bypasses tokenizer and runtime | 0.1 |
-| U-041 | identical concurrent misses coalesce/bound duplicate forwards | 0.1 |
+| U-041 | identical concurrent misses coalesce/bound duplicate forwards; coalesced waiters counted as `cache_coalesced` | 0.1 |
 | U-042 | cache key changes with model/classifier revision | 0.1 |
 | U-043 | cache key changes with tokenizer revision | 0.1 |
 | U-044 | cache key changes with taxonomy/prototype revision | 0.1 |
@@ -56,7 +56,7 @@ Test IDs are evidence anchors. Each version's `test-plan.md` selects the require
 | U-072 | per-classifier deadline/config honored | 0.23 |
 | U-073 | multi-signal result ordering deterministic | 0.23 |
 | U-080 | queue/tokenize/forward/total metrics emitted | 0.1 |
-| U-081 | cache hit/miss counters correct | 0.1 |
+| U-081 | cache hit/miss/coalesced counters correct | 0.1 |
 | U-082 | metric labels bounded | 0.20 |
 | U-083 | session_id is never metric label | 0.20 |
 | U-084 | request_id cannot create metric cardinality | 0.20 |

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -52,25 +52,28 @@ fn u080_queue_tokenize_forward_total_metrics_emitted() {
     assert!(snap.forward <= snap.total);
 }
 
-/// U-081 (AC-012): cache hit/miss counters are correct.
+/// U-081 (AC-012): cache hit/miss/coalesced counters partition every request.
 ///
-/// The metrics registry must count cache hits and misses independently and
-/// exactly. A hit increments the hit counter, a miss increments the miss
-/// counter; neither leaks across the other.
+/// The metrics registry must count cache hits, misses, and coalesced waits
+/// independently and exactly. The three counters partition every request.
+/// (The full three-way partition is exercised in src/metrics.rs unit tests
+/// and in tests/metrics_accuracy.rs with concurrent workloads.)
 #[test]
-fn u081_cache_hit_miss_counters_correct() {
+fn u081_cache_hit_miss_coalesced_counters_correct() {
     let metrics = Metrics::new();
     metrics.record_cache_hit();
     metrics.record_cache_hit();
     metrics.record_cache_miss();
+    metrics.record_cache_coalesced();
 
     let snap: MetricsSnapshot = metrics.snapshot();
     assert_eq!(snap.cache_hits, 2, "two hits must be counted");
     assert_eq!(snap.cache_misses, 1, "one miss must be counted");
+    assert_eq!(snap.cache_coalesced, 1, "one coalesced must be counted");
     assert_eq!(
-        snap.cache_hits + snap.cache_misses,
-        3,
-        "hit + miss counters must partition every request"
+        snap.cache_hits + snap.cache_misses + snap.cache_coalesced,
+        4,
+        "hit + miss + coalesced counters must partition every request"
     );
 }
 

--- a/tests/metrics_accuracy.rs
+++ b/tests/metrics_accuracy.rs
@@ -1,0 +1,204 @@
+//! Metrics accuracy tests for the single-flight cache path (AC-007/AC-012).
+//!
+//! The classification pipeline has three distinct request paths:
+//!   1. TRUE HIT:       cached result, no forward              → cache_hits
+//!   2. TRUE MISS:      real forward (tokenize + embed + rank) → cache_misses
+//!   3. COALESCED WAIT: waited for another thread's forward    → cache_coalesced
+//!
+//! `coalesced_waiters_counted_in_metrics` uses a deliberately slow fake
+//! runtime to make coalescing deterministic without model weights.
+//! `mixed_workload_counters_match_ground_truth` uses the real Candle
+//! classifier and verifies exact ground-truth counters across all three
+//! paths in a mixed workload.
+//!
+//! Ignored tests require fetched weights:
+//!   ./hack/fetch-model --classifier complexity
+//!
+//! Run:
+//!   cargo test --test metrics_accuracy                          # synthetic only
+//!   cargo test --test metrics_accuracy -- --ignored --nocapture # all (needs weights)
+
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
+
+use llm_d_sc::classify::{
+    CandleClassifier, ClassificationInput, ClassificationResult, ClassifierRuntime, ClassifyError,
+    ClassifyStatus, RankedSignal, RuntimeMetadata, ServiceCore,
+};
+use llm_d_sc::metrics::Metrics;
+use llm_d_sc::taxonomy::ClassifierDefinition;
+
+fn classifier() -> CandleClassifier {
+    let def = ClassifierDefinition::built_in("complexity")
+        .unwrap()
+        .unwrap();
+    CandleClassifier::from_modelcar_with(
+        &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("artifacts/models/complexity"),
+        def,
+    )
+    .expect("complexity artifact must load (run ./hack/fetch-model first)")
+}
+
+fn input(text: &str) -> ClassificationInput {
+    ClassificationInput {
+        text: text.to_string(),
+        requested_signals: vec!["complexity".to_string()],
+        session_metadata: Default::default(),
+    }
+}
+
+/// A fake runtime whose forward sleeps long enough for all concurrent
+/// callers to enter the cache layer and hit the in-flight slot before the
+/// designated forwarder completes (same approach as the u041 cache test).
+struct SlowRuntime;
+
+impl ClassifierRuntime for SlowRuntime {
+    fn classify(&self, _input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
+        // Hold the forward open so concurrent callers see the in-flight
+        // slot rather than finding the result already cached.
+        std::thread::sleep(Duration::from_millis(250));
+        Ok(ClassificationResult {
+            classifier_id: "slow".into(),
+            model_revision: "rev".into(),
+            tokenizer_revision: "rev".into(),
+            taxonomy_revision: "rev".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal {
+                id: "label".into(),
+                score: 1.0,
+            }],
+        })
+    }
+
+    fn metadata(&self) -> RuntimeMetadata {
+        RuntimeMetadata {
+            classifier_id: "slow".into(),
+            signal: "test".into(),
+            model_revision: "rev".into(),
+            tokenizer_revision: "rev".into(),
+            taxonomy_revision: "rev".into(),
+            artifact_digest: None,
+        }
+    }
+}
+
+/// U-081 / U-041 (AC-007/AC-012): concurrent identical misses through
+/// ServiceCore record the designated forwarder as a miss and the coalesced
+/// waiters as `cache_coalesced`, not `cache_hits`.
+///
+/// Uses a deliberately blocking fake runtime so the forward stays open
+/// until all threads have entered the cache layer.
+#[test]
+fn coalesced_waiters_counted_in_metrics() {
+    const CONCURRENCY: usize = 8;
+    let metrics = Metrics::new();
+    let core = Arc::new(ServiceCore::with_metrics(SlowRuntime, metrics.clone()));
+
+    let barrier = Arc::new(Barrier::new(CONCURRENCY));
+    let handles: Vec<_> = (0..CONCURRENCY)
+        .map(|_| {
+            let core = Arc::clone(&core);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                core.classify(input("identical burst key"))
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap().expect("burst must succeed");
+    }
+
+    let snap = metrics.snapshot();
+    assert_eq!(
+        snap.cache_hits + snap.cache_misses + snap.cache_coalesced,
+        CONCURRENCY as u64,
+        "all requests must be accounted for"
+    );
+    assert_eq!(snap.cache_misses, 1, "exactly one designated forwarder");
+    assert_eq!(
+        snap.cache_coalesced,
+        (CONCURRENCY as u64) - 1,
+        "all other threads must be counted as coalesced"
+    );
+    assert_eq!(snap.cache_hits, 0, "cold cache must report 0 true hits");
+}
+
+/// U-081 (AC-012): mixed workload — hit/miss/coalesced counters match the
+/// known ground truth exactly.
+///
+/// Phases: 10 distinct misses → 100 true hits → 32 concurrent burst
+/// (1 miss + 31 coalesced). Total 142 requests with no counter inflation.
+#[test]
+#[ignore]
+fn mixed_workload_counters_match_ground_truth() {
+    let metrics = Metrics::new();
+    let core = Arc::new(ServiceCore::with_metrics(classifier(), metrics.clone()));
+
+    // Phase 1: 10 distinct prompts (all true misses).
+    let prompts: Vec<String> = (0..10)
+        .map(|i| format!("distinct prompt number {i} about a unique subject that will not collide"))
+        .collect();
+    for p in &prompts {
+        core.classify(input(p)).expect("miss must succeed");
+    }
+
+    // Phase 2: 100 hits on an already-cached prompt.
+    for _ in 0..100 {
+        core.classify(input(&prompts[0])).expect("hit must succeed");
+    }
+
+    // Phase 3: 32 concurrent requests on a new prompt (1 miss + 31 coalesced).
+    let burst_text =
+        "a completely new prompt that has never been seen by the classifier before now";
+    let barrier = Arc::new(Barrier::new(32));
+    let handles: Vec<_> = (0..32)
+        .map(|_| {
+            let core = Arc::clone(&core);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                core.classify(input(burst_text))
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap().unwrap();
+    }
+
+    let snap = metrics.snapshot();
+    let total = snap.cache_hits + snap.cache_misses + snap.cache_coalesced;
+
+    // Ground truth: 10 phase-1 misses + 1 phase-3 forwarder = 11 misses,
+    // 100 phase-2 hits, 31 phase-3 coalesced waits.
+    let true_hits: u64 = 100;
+    let true_misses: u64 = 11;
+    let true_coalesced: u64 = 31;
+
+    println!();
+    println!("=== Mixed workload metrics accuracy ===");
+    println!("  phase 1: 10 misses  phase 2: 100 hits  phase 3: 1+31 burst");
+    println!(
+        "  hits: {} (expect {true_hits})  misses: {} (expect {true_misses})  \
+         coalesced: {} (expect {true_coalesced})",
+        snap.cache_hits, snap.cache_misses, snap.cache_coalesced
+    );
+    println!(
+        "  hit rate: {:.1}%",
+        snap.cache_hits as f64 / total as f64 * 100.0
+    );
+
+    assert_eq!(total, 142, "all 142 requests must be accounted for");
+    assert_eq!(
+        snap.cache_hits, true_hits,
+        "hit count must match ground truth"
+    );
+    assert_eq!(
+        snap.cache_misses, true_misses,
+        "miss count must match ground truth"
+    );
+    assert_eq!(
+        snap.cache_coalesced, true_coalesced,
+        "coalesced count must match ground truth"
+    );
+}


### PR DESCRIPTION
Single-flight coalesced waiters (AC-007) were counted as cache hits, inflating the reported hit rate. A burst of 8 identical requests produced 1 true miss + 7 "hits" instead of 1 miss + 7 coalesced waits.

## What changed

**`CachePath` enum** (`Hit | Miss | Coalesced`) replaces the per-request `AtomicBool` flag in the classify path. `classify_concurrent` now returns `(Result, CachePath)` so the caller records the correct counter without inferring the path from a side-effect.

**`Metrics`** gains `cache_coalesced` / `record_cache_coalesced()`. The server log and bench harness account for the new counter. `verify_window` rejects unexpected coalescing in both cache modes.

## Before / after

8 concurrent identical requests on a cold cache via `ServiceCore` + `SlowRuntime` (250 ms forward, deterministic coalescing):

| | `cache_hits` | `cache_misses` | `cache_coalesced` | hit rate |
|---|---:|---:|---:|---:|
| **main (before)** | 7 | 1 | — | 87.5% |
| **fix (after)** | 0 | 1 | 7 | 0.0% |

142-request mixed workload (real Candle classifier, `--ignored`):

| | `cache_hits` | `cache_misses` | `cache_coalesced` | hit rate |
|---|---:|---:|---:|---:|
| **main (before)** | 131 | 11 | — | 92.3% |
| **fix (after)** | 100 | 11 | 31 | 70.4% |

## Tests

- `coalesced_waiters_counted_in_metrics`: synthetic `SlowRuntime`, 8-thread burst, exact three-way assertion (non-ignored, no model weights)
- `mixed_workload_counters_match_ground_truth`: real classifier, 142-request phased workload with exact ground truth (ignored, needs weights)
- `methodology_rejects_unexpected_coalescing`: bench harness rejects coalesced waits in both miss-mode and hit-mode windows
- U-081 integration test updated to three-way partition