### PR TITLE
feat: pluggable semantic cache (L1 exact + L2 Redis) with playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "tonic-prost-build",
  "unicode-normalization",
  "unicode_categories",
+ "ureq",
 ]
 
 [[package]]
@@ -2395,6 +2396,18 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +442,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dyn-stack"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +577,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-channel"
@@ -913,10 +943,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -962,6 +1096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "llm-d-sc"
 version = "0.1.0"
 dependencies = [
@@ -970,6 +1110,8 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "prost",
+ "r2d2",
+ "redis",
  "serde",
  "serde_json",
  "tokenizers 0.23.1",
@@ -981,6 +1123,15 @@ dependencies = [
  "tonic-prost-build",
  "unicode-normalization",
  "unicode_categories",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -1089,12 +1240,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
  "num-traits",
 ]
 
@@ -1144,6 +1314,29 @@ checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1206,6 +1399,15 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1353,6 +1555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1651,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "redis"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
+dependencies = [
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "r2d2",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "url",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1753,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1833,12 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "shlex"
@@ -1742,6 +2002,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2102,6 +2372,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2536,39 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +285,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1114,6 +1126,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
+ "tiny_http",
  "tokenizers 0.23.1",
  "tokio",
  "tokio-stream",
@@ -2002,6 +2015,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,13 @@ path = "src/bin/classify.rs"
 name = "llm-d-sc-gateway-probe"
 path = "src/bin/gateway-probe.rs"
 
+# Demo playground: only built when the `playground` feature is enabled, so the
+# default build never pulls tiny_http or the Redis backend.
+[[bin]]
+name = "llm-d-sc-playground"
+path = "src/bin/playground.rs"
+required-features = ["playground"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -50,10 +57,17 @@ tokenizers = { version = "0.23.1", default-features = false, features = ["fancy-
 # rustc >= 1.80, so enabling the feature raises the effective toolchain floor.
 redis = { version = "0.32.2", features = ["r2d2"], optional = true }
 r2d2 = { version = "0.8.10", optional = true }
+# Pure-Rust, dependency-light HTTP server used ONLY by the demo playground
+# binary (feature `playground`). Never compiled into the default build.
+tiny_http = { version = "0.12", optional = true }
 
 [features]
 # Enables the Redis-backed semantic (L2) cache tier. Requires rustc >= 1.80.
 redis-semantic = ["dep:redis", "dep:r2d2"]
+# Builds the interactive demo playground binary (llm-d-sc-playground): a local
+# web UI over the real classifier + semantic cache. Implies redis-semantic, so
+# it also requires rustc >= 1.80.
+playground = ["redis-semantic", "dep:tiny_http"]
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,16 @@ blake3 = "1.8.6"
 # recent macOS/Xcode. A regex backend is mandatory, so fancy-regex (pure Rust)
 # replaces onig (C). The result needs no C or C++ toolchain at all.
 tokenizers = { version = "0.23.1", default-features = false, features = ["fancy-regex"] }
-redis = { version = "0.32.2", features = ["r2d2"] }
-r2d2 = "0.8.10"
+# The Redis semantic (L2) cache backend is optional and off by default. It is
+# gated behind the `redis-semantic` feature so the default build stays
+# dependency-light and keeps MSRV 1.75; the redis crate (0.32) requires
+# rustc >= 1.80, so enabling the feature raises the effective toolchain floor.
+redis = { version = "0.32.2", features = ["r2d2"], optional = true }
+r2d2 = { version = "0.8.10", optional = true }
+
+[features]
+# Enables the Redis-backed semantic (L2) cache tier. Requires rustc >= 1.80.
+redis-semantic = ["dep:redis", "dep:r2d2"]
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ r2d2 = { version = "0.8.10", optional = true }
 # Pure-Rust, dependency-light HTTP server used ONLY by the demo playground
 # binary (feature `playground`). Never compiled into the default build.
 tiny_http = { version = "0.12", optional = true }
+# Blocking HTTP *client* used ONLY by the playground/gateway to forward
+# chat-completion requests upstream to vLLM on a response-cache miss. TLS is
+# dropped (default-features = false): the upstream is a plaintext in-cluster
+# service, so no rustls/native-tls toolchain is pulled in.
+ureq = { version = "2", default-features = false, optional = true }
 
 [features]
 # Enables the Redis-backed semantic (L2) cache tier. Requires rustc >= 1.80.
@@ -67,7 +72,7 @@ redis-semantic = ["dep:redis", "dep:r2d2"]
 # Builds the interactive demo playground binary (llm-d-sc-playground): a local
 # web UI over the real classifier + semantic cache. Implies redis-semantic, so
 # it also requires rustc >= 1.80.
-playground = ["redis-semantic", "dep:tiny_http"]
+playground = ["redis-semantic", "dep:tiny_http", "dep:ureq"]
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ blake3 = "1.8.6"
 # recent macOS/Xcode. A regex backend is mandatory, so fancy-regex (pure Rust)
 # replaces onig (C). The result needs no C or C++ toolchain at all.
 tokenizers = { version = "0.23.1", default-features = false, features = ["fancy-regex"] }
+redis = { version = "0.32.2", features = ["r2d2"] }
+r2d2 = "0.8.10"
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,21 @@ REDIS_URL=redis://127.0.0.1:6379 cargo test --test redis_semantic -- --ignored
 `REDIS_URL` above only configures that test run; the running service reads
 `LLM_D_SC_REDIS_URL` instead.
 
+Two operational constraints apply when the semantic tier is enabled. Both are
+fail-open (they degrade to the normal compute path and never produce a wrong
+label), but they are silent, so plan for them:
+
+- **One embedding dimension per Redis instance.** The vector index is created
+  lazily with the embedding dimension of the first entry written. A classifier
+  whose embeddings have a different dimension, pointed at the same Redis, simply
+  gets no L2 benefit (its writes fail to index and its lookups miss). Give
+  classifiers with different embedding dimensions separate Redis instances.
+- **Keep cache-identity fields comma-free.** Entries are isolated by an identity
+  tag built from the classifier id and the model, tokenizer, and taxonomy
+  revisions, so one classifier or revision never reuses another's labels. That
+  isolation relies on those fields not containing a comma (the tag separator);
+  the built-in classifiers and revision fingerprints already satisfy this.
+
 **4. Call it over gRPC.** The bundled gateway stand-in issues a real call over a
 persistent channel, consumes the signals, and applies its own test-only policy
 afterwards, demonstrating that routing authority stays outside this service:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,35 @@ are comparable WITHIN one response, which is what makes the margin between the
 top two labels meaningful, but they are not calibrated across models or
 taxonomies and should not be read as confidence in a statistical sense.
 
+**Optional: semantic result cache.** Off by default. The built-in exact-match
+cache only reuses a label for the identical text. Setting `LLM_D_SC_CACHE=redis-semantic`
+adds an optional L2 tier behind it: on an exact-cache miss, after the prompt is
+embedded, a semantically similar prior prompt reuses its stored label instead of
+re-ranking. It requires a running
+[Redis Stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)
+(RediSearch) instance and is a best-effort accelerator, not a source of truth: a
+slow or unreachable Redis degrades to the normal compute path (fail-open) and
+never fails the request.
+
+| Env var | Meaning | Default |
+| --- | --- | --- |
+| `LLM_D_SC_CACHE` | Cache strategy: `exact` or `redis-semantic` | `exact` |
+| `LLM_D_SC_REDIS_URL` | Redis Stack URL (e.g. `redis://127.0.0.1:6379`); used only when the strategy is `redis-semantic` | none; required when `redis-semantic` |
+| `LLM_D_SC_CACHE_THRESHOLD` | Cosine similarity gate for a semantic hit; higher is safer but reuses less | `0.90` |
+| `LLM_D_SC_CACHE_TTL` | Cached-label time-to-live, in seconds | `86400` |
+| `LLM_D_SC_CACHE_TIMEOUT_MS` | Per-Redis-operation timeout, in milliseconds | `50` |
+
+To run the live Redis integration tests locally (`#[ignore]`d by default because
+they need a real Redis Stack):
+
+```bash
+./hack/redis-stack.sh &   # start Redis Stack
+REDIS_URL=redis://127.0.0.1:6379 cargo test --test redis_semantic -- --ignored
+```
+
+`REDIS_URL` above only configures that test run; the running service reads
+`LLM_D_SC_REDIS_URL` instead.
+
 **4. Call it over gRPC.** The bundled gateway stand-in issues a real call over a
 persistent channel, consumes the signals, and applies its own test-only policy
 afterwards, demonstrating that routing authority stays outside this service:
@@ -210,6 +239,11 @@ a separate OCI artifact.
                  ▼
    tokenize → transformer → pooling → normalize → rank
 ```
+
+An optional semantic (L2) cache tier can sit behind the exact-result cache: on a
+miss, once the prompt is embedded, a similar-enough prior prompt returns its
+stored label instead of reaching the classifier runtime. It is off by default;
+see "Optional: semantic result cache" under [Quick start](#quick-start) above.
 
 Three properties are load-bearing:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ REDIS_URL=redis://127.0.0.1:6379 \
 `REDIS_URL` above only configures that test run; the running service reads
 `LLM_D_SC_REDIS_URL` instead.
 
+**Interactive playground.** To see the cache behave in a browser, one command
+starts Redis Stack, downloads the model if missing, and serves a local web UI:
+
+```bash
+./hack/playground      # then open http://127.0.0.1:8080
+```
+
+Classify a prompt, then a paraphrase of it: the paraphrase is served as an **L2
+semantic hit** (a similar prior prompt's label is reused after embedding), and
+re-sending the identical text is an **L1 exact hit** returned in well under a
+millisecond. It needs Docker (for Redis Stack) and a one-time ~90 MB model
+download (Python 3 + `huggingface_hub`, installed by the script if absent);
+without Docker it still runs, fail-open, with the exact cache only. The
+playground is built only with `--features playground`, so it never affects the
+default build.
+
 Two operational constraints apply when the semantic tier is enabled. Both are
 fail-open (they degrade to the normal compute path and never produce a wrong
 label), but they are silent, so plan for them:

--- a/README.md
+++ b/README.md
@@ -147,11 +147,17 @@ are comparable WITHIN one response, which is what makes the margin between the
 top two labels meaningful, but they are not calibrated across models or
 taxonomies and should not be read as confidence in a statistical sense.
 
-**Optional: semantic result cache.** Off by default. The built-in exact-match
-cache only reuses a label for the identical text. Setting `LLM_D_SC_CACHE=redis-semantic`
-adds an optional L2 tier behind it: on an exact-cache miss, after the prompt is
-embedded, a semantically similar prior prompt reuses its stored label instead of
-re-ranking. It requires a running
+**Optional: semantic result cache.** Off by default, and not even compiled into
+the default build. The built-in exact-match cache only reuses a label for the
+identical text. The Redis-backed semantic tier is gated behind the
+`redis-semantic` cargo feature, so the default build stays dependency-light and
+keeps MSRV 1.75; enabling the feature pulls in the `redis` crate, which requires
+rustc ≥ 1.80. Build it in with `--features redis-semantic`, then set
+`LLM_D_SC_CACHE=redis-semantic` to add an optional L2 tier behind the exact
+cache: on an exact-cache miss, after the prompt is embedded, a semantically
+similar prior prompt reuses its stored label instead of re-ranking. (A binary
+built without the feature logs a warning and falls back to the exact cache if
+`redis-semantic` is requested at runtime.) It requires a running
 [Redis Stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)
 (RediSearch) instance and is a best-effort accelerator, not a source of truth: a
 slow or unreachable Redis degrades to the normal compute path (fail-open) and
@@ -170,7 +176,8 @@ they need a real Redis Stack):
 
 ```bash
 ./hack/redis-stack.sh &   # start Redis Stack
-REDIS_URL=redis://127.0.0.1:6379 cargo test --test redis_semantic -- --ignored
+REDIS_URL=redis://127.0.0.1:6379 \
+  cargo test --features redis-semantic --test redis_semantic -- --ignored
 ```
 
 `REDIS_URL` above only configures that test run; the running service reads

--- a/README.md
+++ b/README.md
@@ -184,20 +184,24 @@ REDIS_URL=redis://127.0.0.1:6379 \
 `LLM_D_SC_REDIS_URL` instead.
 
 **Interactive playground.** To see the cache behave in a browser, one command
-starts Redis Stack, downloads the model if missing, and serves a local web UI:
+starts Redis Stack (with a clean cache), downloads any missing models, and
+serves a local web UI:
 
 ```bash
 ./hack/playground      # then open http://127.0.0.1:8080
 ```
 
-Classify a prompt, then a paraphrase of it: the paraphrase is served as an **L2
+Pick a classifier (`complexity`, `cost`, or `sensitivity`) from the dropdown,
+classify a prompt, then a paraphrase of it: the paraphrase is served as an **L2
 semantic hit** (a similar prior prompt's label is reused after embedding), and
 re-sending the identical text is an **L1 exact hit** returned in well under a
-millisecond. It needs Docker (for Redis Stack) and a one-time ~90 MB model
-download (Python 3 + `huggingface_hub`, installed by the script if absent);
-without Docker it still runs, fail-open, with the exact cache only. The
-playground is built only with `--features playground`, so it never affects the
-default build.
+millisecond. Each classifier keeps its own isolated cache. The dropdown ships
+per-classifier example prompts to try. It needs Docker (for Redis Stack) and a
+one-time ~90 MB download per model (Python 3 + `huggingface_hub`, installed by
+the script if absent); without Docker it still runs, fail-open, with the exact
+cache only. Set `LLM_D_SC_CLASSIFIER=complexity` to demo a single classifier.
+The playground is built only with `--features playground`, so it never affects
+the default build.
 
 Two operational constraints apply when the semantic tier is enabled. Both are
 fail-open (they degrade to the normal compute path and never produce a wrong

--- a/docs/superpowers/plans/2026-08-30-semantic-cache-classifier.md
+++ b/docs/superpowers/plans/2026-08-30-semantic-cache-classifier.md
@@ -1,0 +1,1649 @@
+# Semantic Cache Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional, off-by-default Redis-backed semantic cache tier that lets semantically-similar prompts reuse a stored classification label, layered above the existing in-memory exact (1:1) cache.
+
+**Architecture:** Split the `ClassifierRuntime` forward into `embed` + `rank` (embed once), introduce a `SemanticCache` strategy trait (`NoopSemanticCache` default, `RedisSemanticCache` opt-in), and have `ServiceCore` orchestrate `L1 exact → embed → L2 semantic KNN → rank → write-back`. Redis is best-effort and fail-open: any Redis error degrades to compute and never fails a request.
+
+**Tech Stack:** Rust (edition 2021, rustc ≥ 1.75), Candle BERT embeddings (already present), `redis` crate (sync API + `r2d2` pool) against Redis Stack / Redis 8+ (RediSearch vector index), blake3 (existing L1 key).
+
+**Spec:** `docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md`
+
+## Global Constraints
+
+- Edition 2021, `rust-version = 1.75`; do not raise the MSRV.
+- No network access on the default path. The semantic tier is **off by default** (`LLM_D_SC_CACHE=exact`); when off, behavior must be byte-for-byte identical to today.
+- **Fail-open, always:** every Redis error/timeout returns "no hit" (lookup) or is dropped (insert); classification never returns an error because of Redis.
+- Preserve the existing L1 exact cache, single-flight coalescing, FIFO eviction, and the blake3 versioned `CacheKey` unchanged.
+- Preserve `CandleClassifier`'s `tokenizer_calls` / `forward_calls` counter semantics: a cache MISS runs exactly one tokenize and one model forward; a cache HIT runs zero of each. (Enforced by `service_core_production_candle_cache_hit_zero_tokenizer_zero_forward` in `src/classify.rs`.)
+- The classifier response never carries a route/endpoint field (AC-010). Do not add one.
+- Follow existing patterns: typed errors (no `unwrap` on I/O), `//!` module docs, `#[ignore]` for tests requiring external resources (model weights / live Redis), `KNOWN_*` registry + validated config.
+- Use `cargo add` for new dependencies (do not hand-pin versions): `cargo add redis --features r2d2`, `cargo add r2d2`.
+
+---
+
+### Task 1: `Embedding` value type
+
+**Files:**
+- Modify: `src/classify.rs` (add type near `ClassificationInput`, ~line 63)
+- Test: `src/classify.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `pub struct Embedding { pub vector: Vec<f32> }` with `Embedding::new(Vec<f32>) -> Embedding` and `fn dim(&self) -> usize`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn embedding_reports_its_dimension() {
+    let e = Embedding::new(vec![0.0, 1.0, 0.0]);
+    assert_eq!(e.dim(), 3);
+    assert_eq!(e.vector, vec![0.0, 1.0, 0.0]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib classify::tests::embedding_reports_its_dimension`
+Expected: FAIL — `cannot find type Embedding`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+/// A classifier-produced embedding: the L2-normalized vector the ranker and the
+/// semantic cache both consume. Produced exactly once per classification so the
+/// (expensive) model forward is never repeated for a cache lookup.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Embedding {
+    pub vector: Vec<f32>,
+}
+
+impl Embedding {
+    /// Wrap a raw embedding vector.
+    pub fn new(vector: Vec<f32>) -> Self {
+        Embedding { vector }
+    }
+
+    /// The embedding dimension.
+    pub fn dim(&self) -> usize {
+        self.vector.len()
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib classify::tests::embedding_reports_its_dimension`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/classify.rs
+git commit -s -m "feat(classify): add Embedding value type for two-stage forward"
+```
+
+---
+
+### Task 2: Split `ClassifierRuntime` into `embed` + `rank` with a default `classify`
+
+This is the architectural pivot. Add two required methods and a provided `classify`, then port `CandleClassifier` and `ClassifyService` to implement `embed`/`rank` (dropping their explicit `classify`). `ServiceCore` keeps its own `classify` override and delegates `embed`/`rank` to the inner runtime.
+
+**Files:**
+- Modify: `src/classify.rs` — `ClassifierRuntime` trait (~line 141), `CandleClassifier` impl (~line 552), `ClassifyService` impl (~line 728), `ServiceCore` impl (~line 247)
+- Test: `src/classify.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `Embedding` (Task 1).
+- Produces:
+  ```rust
+  fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError>;
+  fn rank(&self, embedding: &Embedding, input: &ClassificationInput) -> Result<ClassificationResult, ClassifyError>;
+  // provided:
+  fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/classify.rs`. This proves the split reproduces the synthetic path exactly, and that `embed` is callable independently.
+
+```rust
+#[test]
+fn embed_then_rank_matches_classify_on_synthetic() {
+    let svc = ClassifyService::from_synthetic_fixtures();
+    let input = ClassificationInput {
+        text: "this is a golden sensitivity input".to_string(),
+        requested_signals: vec!["sensitivity".to_string()],
+        session_metadata: HashMap::new(),
+    };
+    // Two-stage path.
+    let embedding = svc.embed(&input).expect("embed");
+    assert_eq!(embedding.dim(), SYNTHETIC_DIM);
+    let staged = svc.rank(&embedding, &input).expect("rank");
+    // Provided classify() default must produce the identical result.
+    let one_shot = svc.classify(input).expect("classify");
+    assert_eq!(staged, one_shot, "embed+rank must equal the provided classify");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib classify::tests::embed_then_rank_matches_classify_on_synthetic`
+Expected: FAIL — `no method named embed`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+3a. Replace the `ClassifierRuntime` trait body (keep the doc comment):
+
+```rust
+pub trait ClassifierRuntime {
+    /// Embed `input` into its (L2-normalized) vector. This is the expensive
+    /// model-forward stage; it runs at most once per classification so a cache
+    /// lookup never repeats it.
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError>;
+
+    /// Rank a previously-computed `embedding` into typed semantic evidence.
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError>;
+
+    /// Classify `input`: embed once, then rank. Backends inherit this; the
+    /// caching core overrides it to interpose the exact and semantic caches.
+    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
+        let embedding = self.embed(&input)?;
+        self.rank(&embedding, &input)
+    }
+
+    /// The immutable identity of what this runtime actually loaded.
+    fn metadata(&self) -> RuntimeMetadata;
+}
+```
+
+3b. Port `CandleClassifier`. Replace `real_forward` and the `impl ClassifierRuntime for CandleClassifier` `classify` with `embed`/`rank`. Keep the counter semantics: `embed` increments BOTH `tokenizer_calls` and `forward_calls` (embed_ids is the model forward) and records the `Tokenize` + `Forward` stages; `rank` increments neither.
+
+```rust
+impl ClassifierRuntime for CandleClassifier {
+    fn metadata(&self) -> RuntimeMetadata { /* unchanged */ }
+
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        let text = input.text.trim();
+        // Tokenize stage (AC-012).
+        let tokenize_start = std::time::Instant::now();
+        self.tokenizer_calls.fetch_add(1, Ordering::SeqCst);
+        let ids = self
+            .embedder
+            .tokenize(text)
+            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
+        // Forward stage (AC-012): the real model forward.
+        let forward_start = std::time::Instant::now();
+        self.forward_calls.fetch_add(1, Ordering::SeqCst);
+        let vector = self
+            .embedder
+            .embed_ids(ids)
+            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Forward, forward_start.elapsed());
+        Ok(Embedding::new(vector))
+    }
+
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        let v = &embedding.vector;
+        let (ranked, identity) = match self.taxonomy.as_ref() {
+            Some(t) => (
+                anchor_rank(v, &t.anchors, t.top_k),
+                (t.classifier_id.clone(), t.model_revision.clone(), t.taxonomy_revision.clone()),
+            ),
+            None => (
+                cosine_rank(v, &self.prototypes),
+                (CLASSIFIER_ID.to_string(), MODEL_REVISION.to_string(), TAXONOMY_REVISION.to_string()),
+            ),
+        };
+        let tokenizer_revision = self
+            .taxonomy
+            .as_ref()
+            .map(|t| t.tokenizer_revision.clone())
+            .unwrap_or_else(|| TOKENIZER_REVISION.to_string());
+        let ranked = ranked
+            .into_iter()
+            .map(|(id, score)| RankedSignal { id, score })
+            .collect();
+        Ok(ClassificationResult {
+            classifier_id: identity.0,
+            model_revision: identity.1,
+            tokenizer_revision,
+            taxonomy_revision: identity.2,
+            status: ClassifyStatus::Ok,
+            ranked,
+        })
+    }
+}
+```
+
+Delete the now-unused `real_forward` method.
+
+3c. Port `ClassifyService` (synthetic). Replace its `impl ClassifierRuntime` `classify` and refactor `deterministic_classify`:
+
+```rust
+impl ClassifierRuntime for ClassifyService {
+    fn metadata(&self) -> RuntimeMetadata { /* unchanged */ }
+
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        let context = input.text.trim();
+        let tokenize_start = std::time::Instant::now();
+        let ids = self
+            .tokenizer
+            .tokenize(context)
+            .map_err(|e| ClassifyError::Tokenizer(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
+        let mut vector = vec![0.0f32; SYNTHETIC_DIM];
+        for id in ids {
+            vector[(id as usize) % SYNTHETIC_DIM] += 1.0;
+        }
+        Ok(Embedding::new(vector))
+    }
+
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        let forward_start = std::time::Instant::now();
+        let ranked = cosine_rank(&embedding.vector, &self.prototypes)
+            .into_iter()
+            .map(|(id, score)| RankedSignal { id, score })
+            .collect();
+        self.metrics
+            .record_stage(LatencyStage::Forward, forward_start.elapsed());
+        Ok(ClassificationResult {
+            classifier_id: CLASSIFIER_ID.to_string(),
+            model_revision: MODEL_REVISION.to_string(),
+            tokenizer_revision: TOKENIZER_REVISION.to_string(),
+            taxonomy_revision: TAXONOMY_REVISION.to_string(),
+            status: ClassifyStatus::Ok,
+            ranked,
+        })
+    }
+}
+```
+
+Delete the now-unused `deterministic_classify` method.
+
+3d. Add `embed`/`rank` delegation to `ServiceCore`'s `impl ClassifierRuntime` (it keeps its own `classify` override from the existing code, unchanged for now — the L2 wiring lands in Task 4):
+
+```rust
+fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+    self.runtime.embed(input)
+}
+fn rank(
+    &self,
+    embedding: &Embedding,
+    input: &ClassificationInput,
+) -> Result<ClassificationResult, ClassifyError> {
+    self.runtime.rank(embedding, input)
+}
+```
+
+- [ ] **Step 4: Run the full lib test suite to verify no regression**
+
+Run: `cargo test --lib`
+Expected: PASS, including `u070_*`, `u071_*`, `u001_*`, and the new `embed_then_rank_matches_classify_on_synthetic`. (Weight/parity `#[ignore]`d tests remain ignored.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/classify.rs
+git commit -s -m "refactor(classify): split ClassifierRuntime into embed+rank, keep classify as default"
+```
+
+---
+
+### Task 3: `SemanticCache` trait + `NoopSemanticCache` + identity tag helper
+
+**Files:**
+- Modify: `src/cache.rs` (append trait + noop + helper; add `use crate::classify::Embedding;`)
+- Test: `src/cache.rs` (`#[cfg(test)] mod semantic_tests`)
+
+**Interfaces:**
+- Consumes: `Embedding`, `ClassificationResult`.
+- Produces:
+  ```rust
+  pub trait SemanticCache: Send + Sync {
+      fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult>;
+      fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str);
+  }
+  pub struct NoopSemanticCache;
+  pub fn identity_tag(id: (&str, &str, &str, &str)) -> String;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod semantic_tests {
+    use super::*;
+    use crate::classify::{ClassificationResult, ClassifyStatus, Embedding, RankedSignal};
+
+    fn result(id: &str) -> ClassificationResult {
+        ClassificationResult {
+            classifier_id: "c".into(), model_revision: "m".into(),
+            tokenizer_revision: "t".into(), taxonomy_revision: "x".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal { id: id.into(), score: 1.0 }],
+        }
+    }
+
+    #[test]
+    fn noop_semantic_cache_never_hits() {
+        let cache = NoopSemanticCache;
+        let e = Embedding::new(vec![1.0, 0.0]);
+        cache.insert(&e, &result("simple"), "c|m|t|x");
+        assert!(cache.lookup(&e, "c|m|t|x").is_none(), "noop must always miss");
+    }
+
+    #[test]
+    fn identity_tag_is_stable_and_field_separated() {
+        assert_eq!(identity_tag(("c", "m", "t", "x")), "c|m|t|x");
+        assert_ne!(identity_tag(("a", "bc", "d", "e")), identity_tag(("ab", "c", "d", "e")));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib cache::semantic_tests`
+Expected: FAIL — `cannot find type NoopSemanticCache`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+use crate::classify::Embedding;
+
+/// The pluggable L2 (semantic / approximate) cache seam.
+///
+/// Interposes on the embedding between `embed` and `rank`. It is BEST-EFFORT:
+/// `lookup` returns `None` on any error (fail-open to compute) and `insert`
+/// is fire-and-forget. `identity` isolates entries by classifier/model/
+/// tokenizer/taxonomy so a revision change can never serve a stale label.
+pub trait SemanticCache: Send + Sync {
+    /// Return a stored result whose embedding is within the configured
+    /// similarity threshold of `embedding` and shares `identity`, else `None`.
+    fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult>;
+
+    /// Record `result` under `embedding` and `identity`. Best-effort; never blocks.
+    fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str);
+}
+
+/// The default L2 cache: always misses, never stores. Zero cost when the
+/// semantic tier is disabled.
+pub struct NoopSemanticCache;
+
+impl SemanticCache for NoopSemanticCache {
+    fn lookup(&self, _embedding: &Embedding, _identity: &str) -> Option<ClassificationResult> {
+        None
+    }
+    fn insert(&self, _embedding: &Embedding, _result: &ClassificationResult, _identity: &str) {}
+}
+
+/// Build the L2 isolation tag from a cache-identity tuple (same fields as the
+/// blake3 L1 key), pipe-separated so field boundaries cannot alias.
+pub fn identity_tag(id: (&str, &str, &str, &str)) -> String {
+    format!("{}|{}|{}|{}", id.0, id.1, id.2, id.3)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib cache::semantic_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cache.rs
+git commit -s -m "feat(cache): add SemanticCache trait, NoopSemanticCache, identity_tag"
+```
+
+---
+
+### Task 4: Wire the L2 tier into `ServiceCore` (default Noop, behavior unchanged)
+
+**Files:**
+- Modify: `src/classify.rs` — `ServiceCore` struct + constructors + `classify` override (~lines 205-314)
+- Test: `src/classify.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `SemanticCache`, `NoopSemanticCache`, `identity_tag` (Task 3); `embed`/`rank` (Task 2).
+- Produces: `ServiceCore::with_semantic_cache(runtime, metrics, Arc<dyn SemanticCache>) -> Self`; the two-tier orchestration in `ServiceCore::classify`.
+
+- [ ] **Step 1: Write the failing test**
+
+A spy `SemanticCache` proves ServiceCore consults L2 on an L1 miss and serves its hit without ranking; and that a default `ServiceCore` (Noop) is unaffected.
+
+```rust
+#[test]
+fn service_core_serves_semantic_hit_without_ranking() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc as StdArc;
+    use crate::cache::SemanticCache;
+
+    struct SpyCache {
+        canned: ClassificationResult,
+        lookups: StdArc<AtomicUsize>,
+    }
+    impl SemanticCache for SpyCache {
+        fn lookup(&self, _e: &Embedding, _id: &str) -> Option<ClassificationResult> {
+            self.lookups.fetch_add(1, Ordering::SeqCst);
+            Some(self.canned.clone())
+        }
+        fn insert(&self, _e: &Embedding, _r: &ClassificationResult, _id: &str) {}
+    }
+
+    let canned = ClassificationResult {
+        classifier_id: "spy".into(), model_revision: "m".into(),
+        tokenizer_revision: "t".into(), taxonomy_revision: "x".into(),
+        status: ClassifyStatus::Ok,
+        ranked: vec![RankedSignal { id: "SEMANTIC_HIT".into(), score: 0.99 }],
+    };
+    let lookups = StdArc::new(AtomicUsize::new(0));
+    let spy = StdArc::new(SpyCache { canned: canned.clone(), lookups: lookups.clone() });
+
+    let core = ServiceCore::with_semantic_cache(
+        ClassifyService::from_synthetic_fixtures(),
+        Metrics::new(),
+        spy,
+    );
+    let input = ClassificationInput {
+        text: "some novel prompt not seen before".to_string(),
+        requested_signals: vec!["sensitivity".to_string()],
+        session_metadata: HashMap::new(),
+    };
+    let out = core.classify(input).expect("classify");
+    assert_eq!(lookups.load(Ordering::SeqCst), 1, "L1 miss must consult L2 once");
+    assert_eq!(out.ranked[0].id, "SEMANTIC_HIT", "L2 hit must be served verbatim");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib classify::tests::service_core_serves_semantic_hit_without_ranking`
+Expected: FAIL — `no function named with_semantic_cache`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+3a. Add the field and import:
+
+```rust
+use crate::cache::{identity_tag, CacheKey, NoopSemanticCache, SemanticCache, SharedCache};
+// ...
+#[derive(Clone)]
+pub struct ServiceCore<R> {
+    runtime: Arc<R>,
+    cache: SharedCache,
+    semantic: Arc<dyn SemanticCache>,
+    metrics: Metrics,
+}
+```
+
+3b. Default constructors keep Noop; add the opt-in constructor:
+
+```rust
+pub fn with_metrics(runtime: R, metrics: Metrics) -> Self {
+    ServiceCore {
+        runtime: Arc::new(runtime),
+        cache: SharedCache::new(),
+        semantic: Arc::new(NoopSemanticCache),
+        metrics,
+    }
+}
+
+/// Build a service core with an explicit L2 semantic cache tier.
+pub fn with_semantic_cache(
+    runtime: R,
+    metrics: Metrics,
+    semantic: Arc<dyn SemanticCache>,
+) -> Self {
+    ServiceCore {
+        runtime: Arc::new(runtime),
+        cache: SharedCache::new(),
+        semantic,
+        metrics,
+    }
+}
+```
+
+3c. Replace the forward closure in `ServiceCore::classify` so the L1-miss path runs `embed → L2 lookup → rank → L2 insert`. Keep the `forward_ran` flag (it still partitions L1 hit/miss metrics) and the existing key construction:
+
+```rust
+let tag = identity_tag(meta.cache_identity());
+let forward = {
+    let runtime = self.runtime.clone();
+    let semantic = self.semantic.clone();
+    let forward_ran = forward_ran.clone();
+    let tag = tag.clone();
+    let input = ClassificationInput {
+        text: normalized,
+        requested_signals: input.requested_signals,
+        session_metadata: input.session_metadata,
+    };
+    move || {
+        forward_ran.store(true, Ordering::SeqCst);
+        // Embed once. Reused by both the L2 lookup and the ranker.
+        let embedding = runtime.embed(&input)?;
+        // L2 semantic lookup (fail-open: None on any Redis trouble).
+        if let Some(hit) = semantic.lookup(&embedding, &tag) {
+            return Ok(hit);
+        }
+        // L2 miss: rank, then best-effort write-back.
+        let result = runtime.rank(&embedding, &input)?;
+        semantic.insert(&embedding, &result, &tag);
+        Ok(result)
+    }
+};
+let result = self.cache.classify_concurrent(key, forward);
+```
+
+Note: `meta` is already bound above (`let meta = self.runtime.metadata();`). Compute `tag` right after it.
+
+- [ ] **Step 4: Run the full lib suite**
+
+Run: `cargo test --lib`
+Expected: PASS — new test passes, and `u071_*` (Noop default) still passes unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/classify.rs
+git commit -s -m "feat(classify): orchestrate L1->embed->L2->rank in ServiceCore (Noop default)"
+```
+
+---
+
+### Task 5: Cache configuration + strategy registry
+
+**Files:**
+- Modify: `src/config.rs`
+- Test: `src/config.rs` (`mod tests`)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub const KNOWN_CACHE_STRATEGIES: &[&str] = &["exact", "redis-semantic"];
+  pub struct CacheConfig {
+      pub strategy: String,      // "exact" | "redis-semantic"
+      pub redis_url: Option<String>,
+      pub threshold: f32,        // cosine similarity, 0.0..=1.0
+      pub ttl_secs: u64,
+      pub timeout_ms: u64,
+  }
+  impl CacheConfig { pub fn from_env() -> Result<CacheConfig, ConfigError>; }
+  // new ConfigError variants: UnknownCacheStrategy(String), MissingRedisUrl, InvalidThreshold(f32)
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn cache_config_defaults_to_exact() {
+    let cfg = CacheConfig::from_env_with(|_| None).expect("defaults");
+    assert_eq!(cfg.strategy, "exact");
+    assert!(cfg.redis_url.is_none());
+    assert!((cfg.threshold - 0.90).abs() < 1e-6);
+    assert_eq!(cfg.ttl_secs, 86_400);
+    assert_eq!(cfg.timeout_ms, 50);
+}
+
+#[test]
+fn redis_semantic_requires_url() {
+    let get = |k: &str| match k {
+        "LLM_D_SC_CACHE" => Some("redis-semantic".to_string()),
+        _ => None,
+    };
+    match CacheConfig::from_env_with(get) {
+        Err(ConfigError::MissingRedisUrl) => {}
+        other => panic!("expected MissingRedisUrl, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_cache_strategy_rejected() {
+    let get = |k: &str| match k {
+        "LLM_D_SC_CACHE" => Some("memcached".to_string()),
+        _ => None,
+    };
+    match CacheConfig::from_env_with(get) {
+        Err(ConfigError::UnknownCacheStrategy(s)) => assert_eq!(s, "memcached"),
+        other => panic!("expected UnknownCacheStrategy, got {other:?}"),
+    }
+}
+
+#[test]
+fn threshold_out_of_range_rejected() {
+    let get = |k: &str| match k {
+        "LLM_D_SC_CACHE" => Some("exact".to_string()),
+        "LLM_D_SC_CACHE_THRESHOLD" => Some("1.5".to_string()),
+        _ => None,
+    };
+    match CacheConfig::from_env_with(get) {
+        Err(ConfigError::InvalidThreshold(v)) => assert!((v - 1.5).abs() < 1e-6),
+        other => panic!("expected InvalidThreshold, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib config::tests::cache_config_defaults_to_exact`
+Expected: FAIL — `cannot find type CacheConfig`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/config.rs`:
+
+```rust
+/// Cache strategies this crate can host.
+pub const KNOWN_CACHE_STRATEGIES: &[&str] = &["exact", "redis-semantic"];
+
+/// L2 semantic-cache configuration, resolved from the environment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheConfig {
+    pub strategy: String,
+    pub redis_url: Option<String>,
+    pub threshold: f32,
+    pub ttl_secs: u64,
+    pub timeout_ms: u64,
+}
+
+impl CacheConfig {
+    /// Resolve from process environment variables.
+    pub fn from_env() -> Result<CacheConfig, ConfigError> {
+        Self::from_env_with(|k| std::env::var(k).ok())
+    }
+
+    /// Resolve from an arbitrary getter (injected for tests).
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Result<CacheConfig, ConfigError> {
+        let strategy = get("LLM_D_SC_CACHE").unwrap_or_else(|| "exact".to_string());
+        if !KNOWN_CACHE_STRATEGIES.contains(&strategy.as_str()) {
+            return Err(ConfigError::UnknownCacheStrategy(strategy));
+        }
+        let redis_url = get("LLM_D_SC_REDIS_URL").filter(|s| !s.trim().is_empty());
+        if strategy == "redis-semantic" && redis_url.is_none() {
+            return Err(ConfigError::MissingRedisUrl);
+        }
+        let threshold = get("LLM_D_SC_CACHE_THRESHOLD")
+            .map(|s| s.parse::<f32>().map_err(|_| ConfigError::InvalidThreshold(f32::NAN)))
+            .transpose()?
+            .unwrap_or(0.90);
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(ConfigError::InvalidThreshold(threshold));
+        }
+        let ttl_secs = get("LLM_D_SC_CACHE_TTL")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(86_400);
+        let timeout_ms = get("LLM_D_SC_CACHE_TIMEOUT_MS")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(50);
+        Ok(CacheConfig { strategy, redis_url, threshold, ttl_secs, timeout_ms })
+    }
+}
+```
+
+Extend `ConfigError`:
+
+```rust
+pub enum ConfigError {
+    MissingClassifiers,
+    UnknownBackend(String),
+    DuplicateClassifierId(String),
+    InvalidModelPath(String),
+    Parse(String),
+    UnknownCacheStrategy(String),
+    MissingRedisUrl,
+    InvalidThreshold(f32),
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib config::tests`
+Expected: PASS (all new + existing `u001..u005`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs
+git commit -s -m "feat(config): add CacheConfig + redis-semantic strategy registry"
+```
+
+---
+
+### Task 6: Circuit breaker (pure, unit-tested)
+
+Keeps a dead/slow Redis from costing one timeout per request: after N consecutive failures, `allow()` returns false for a cooldown window.
+
+**Files:**
+- Create: `src/cache/breaker.rs`
+- Modify: `src/cache.rs` — add `pub mod breaker;` (convert `cache.rs` usage as needed; keep `cache.rs` as the module root and add the submodule declaration at its top)
+- Test: `src/cache/breaker.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct CircuitBreaker { /* private */ }
+  impl CircuitBreaker {
+      pub fn new(failure_threshold: u32, cooldown: std::time::Duration) -> Self;
+      pub fn allow(&self) -> bool;
+      pub fn record_success(&self);
+      pub fn record_failure(&self);
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn opens_after_threshold_and_closes_after_cooldown() {
+        let cb = CircuitBreaker::new(2, Duration::from_millis(50));
+        assert!(cb.allow(), "starts closed");
+        cb.record_failure();
+        assert!(cb.allow(), "one failure below threshold");
+        cb.record_failure();
+        assert!(!cb.allow(), "opens at threshold");
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(cb.allow(), "closes (half-open) after cooldown");
+    }
+
+    #[test]
+    fn success_resets_failures() {
+        let cb = CircuitBreaker::new(2, Duration::from_secs(10));
+        cb.record_failure();
+        cb.record_success();
+        cb.record_failure();
+        assert!(cb.allow(), "success cleared the earlier failure");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib cache::breaker`
+Expected: FAIL — `cannot find type CircuitBreaker`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/cache/breaker.rs`:
+
+```rust
+//! A minimal consecutive-failure circuit breaker for the best-effort L2 cache.
+//! After `failure_threshold` consecutive failures it opens for `cooldown`,
+//! so a dead Redis costs one probe per cooldown window, not one per request.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+struct State {
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
+}
+
+pub struct CircuitBreaker {
+    failure_threshold: u32,
+    cooldown: Duration,
+    state: Mutex<State>,
+}
+
+impl CircuitBreaker {
+    pub fn new(failure_threshold: u32, cooldown: Duration) -> Self {
+        CircuitBreaker {
+            failure_threshold: failure_threshold.max(1),
+            cooldown,
+            state: Mutex::new(State { consecutive_failures: 0, open_until: None }),
+        }
+    }
+
+    /// True if a call may proceed (closed, or half-open after cooldown).
+    pub fn allow(&self) -> bool {
+        let mut s = self.state.lock().unwrap();
+        match s.open_until {
+            Some(t) if Instant::now() < t => false,
+            Some(_) => {
+                // Cooldown elapsed: half-open, let one probe through.
+                s.open_until = None;
+                s.consecutive_failures = 0;
+                true
+            }
+            None => true,
+        }
+    }
+
+    pub fn record_success(&self) {
+        let mut s = self.state.lock().unwrap();
+        s.consecutive_failures = 0;
+        s.open_until = None;
+    }
+
+    pub fn record_failure(&self) {
+        let mut s = self.state.lock().unwrap();
+        s.consecutive_failures += 1;
+        if s.consecutive_failures >= self.failure_threshold {
+            s.open_until = Some(Instant::now() + self.cooldown);
+        }
+    }
+}
+```
+
+Add to the top of `src/cache.rs`: `pub mod breaker;`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib cache::breaker`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cache.rs src/cache/breaker.rs
+git commit -s -m "feat(cache): add consecutive-failure circuit breaker"
+```
+
+---
+
+### Task 7: Redis entry codec + KNN query builder (pure, unit-tested)
+
+Isolate every piece of the Redis integration that does NOT need a live server: the vector→bytes encoding, the `FT.SEARCH` KNN argument list, the index name, and the result JSON codec. This makes Task 8 thin.
+
+**Files:**
+- Create: `src/cache/redis_codec.rs`
+- Modify: `src/cache.rs` — add `pub mod redis_codec;`
+- Test: `src/cache/redis_codec.rs` (inline `#[cfg(test)]`)
+- Add dependency: `cargo add serde_json` is already present; no new dep here.
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub fn vector_to_bytes(v: &[f32]) -> Vec<u8>;             // little-endian f32 blob
+  pub fn index_name() -> &'static str;                       // "sc_semantic_idx"
+  pub fn encode_result(r: &crate::classify::ClassificationResult) -> String;   // JSON
+  pub fn decode_result(s: &str) -> Option<crate::classify::ClassificationResult>;
+  pub fn cosine_score_from_distance(distance: f32) -> f32;   // 1.0 - distance
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify::{ClassificationResult, ClassifyStatus, RankedSignal};
+
+    #[test]
+    fn vector_bytes_are_little_endian_f32() {
+        let bytes = vector_to_bytes(&[1.0f32, 2.0f32]);
+        assert_eq!(bytes.len(), 8);
+        assert_eq!(&bytes[0..4], &1.0f32.to_le_bytes());
+        assert_eq!(&bytes[4..8], &2.0f32.to_le_bytes());
+    }
+
+    #[test]
+    fn result_round_trips_through_json() {
+        let r = ClassificationResult {
+            classifier_id: "complexity".into(), model_revision: "m".into(),
+            tokenizer_revision: "t".into(), taxonomy_revision: "x".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal { id: "SIMPLE".into(), score: 0.87 }],
+        };
+        let encoded = encode_result(&r);
+        let decoded = decode_result(&encoded).expect("decode");
+        assert_eq!(decoded, r);
+    }
+
+    #[test]
+    fn cosine_score_is_one_minus_distance() {
+        assert!((cosine_score_from_distance(0.1) - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bad_json_decodes_to_none() {
+        assert!(decode_result("not json").is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib cache::redis_codec`
+Expected: FAIL — `cannot find function vector_to_bytes`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+This requires `serde` derives on the result types. Add `#[derive(serde::Serialize, serde::Deserialize)]` to `ClassificationResult`, `RankedSignal`, and `ClassifyStatus` in `src/classify.rs` (they already derive `Debug, Clone, PartialEq`). Then:
+
+`src/cache/redis_codec.rs`:
+
+```rust
+//! Pure (no-I/O) codec + query-shape helpers for the Redis semantic cache, so
+//! the byte encoding, index name, and result serialization are unit-testable
+//! without a live Redis.
+
+use crate::classify::ClassificationResult;
+
+/// The RediSearch index over the semantic-cache hash keys.
+pub fn index_name() -> &'static str {
+    "sc_semantic_idx"
+}
+
+/// Encode an embedding as the little-endian f32 blob RediSearch expects for a
+/// FLOAT32 vector field.
+pub fn vector_to_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Serialize a classification result for storage.
+pub fn encode_result(r: &ClassificationResult) -> String {
+    serde_json::to_string(r).expect("ClassificationResult serializes")
+}
+
+/// Deserialize a stored result; `None` on any corruption (treated as a miss).
+pub fn decode_result(s: &str) -> Option<ClassificationResult> {
+    serde_json::from_str(s).ok()
+}
+
+/// RediSearch returns COSINE *distance* (0 = identical). Convert to a
+/// similarity score in [0, 1] for threshold comparison.
+pub fn cosine_score_from_distance(distance: f32) -> f32 {
+    1.0 - distance
+}
+```
+
+Add `pub mod redis_codec;` to `src/cache.rs`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib cache::redis_codec`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cache.rs src/cache/redis_codec.rs src/classify.rs
+git commit -s -m "feat(cache): add pure Redis codec/query helpers + serde on result types"
+```
+
+---
+
+### Task 8: `RedisSemanticCache` — lookup with fail-open + circuit breaker
+
+Implements `SemanticCache` against Redis Stack. Uses the sync `redis` crate with an `r2d2` pool and per-op timeouts. Lookup wraps every Redis interaction so ANY error returns `None`. Live-Redis behavior is exercised by an `#[ignore]`d integration test (repo convention for external resources); the fail-open path is unit-tested without a server by pointing at a dead address.
+
+**Files:**
+- Create: `src/cache/redis.rs`
+- Modify: `src/cache.rs` — add `pub mod redis;`
+- Test: `tests/redis_semantic.rs` (integration; `#[ignore]` for the live-Redis cases)
+- Add dependencies: `cargo add redis --features r2d2` and `cargo add r2d2`
+
+**Interfaces:**
+- Consumes: `SemanticCache`, `CircuitBreaker`, `redis_codec::*`, `CacheConfig`.
+- Produces:
+  ```rust
+  pub struct RedisSemanticCache { /* private */ }
+  impl RedisSemanticCache {
+      pub fn connect(cfg: &crate::config::CacheConfig, metrics: crate::metrics::Metrics)
+          -> Result<RedisSemanticCache, String>;
+  }
+  impl crate::cache::SemanticCache for RedisSemanticCache { /* lookup + insert */ }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/redis_semantic.rs`:
+
+```rust
+use llm_d_sc::cache::redis::RedisSemanticCache;
+use llm_d_sc::cache::SemanticCache;
+use llm_d_sc::classify::{ClassificationResult, ClassifyStatus, Embedding, RankedSignal};
+use llm_d_sc::config::CacheConfig;
+use llm_d_sc::metrics::Metrics;
+
+fn cfg(url: &str) -> CacheConfig {
+    CacheConfig {
+        strategy: "redis-semantic".into(),
+        redis_url: Some(url.into()),
+        threshold: 0.90,
+        ttl_secs: 3600,
+        timeout_ms: 50,
+    }
+}
+
+fn result(id: &str) -> ClassificationResult {
+    ClassificationResult {
+        classifier_id: "complexity".into(), model_revision: "m".into(),
+        tokenizer_revision: "t".into(), taxonomy_revision: "x".into(),
+        status: ClassifyStatus::Ok,
+        ranked: vec![RankedSignal { id: id.into(), score: 0.9 }],
+    }
+}
+
+#[test]
+fn lookup_is_fail_open_when_redis_is_unreachable() {
+    // Port 1 is never a Redis; connect may succeed lazily, but lookup must
+    // never panic or error — it returns None (fail-open to compute).
+    let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), Metrics::new());
+    if let Ok(cache) = cache {
+        let e = Embedding::new(vec![0.1, 0.2, 0.3]);
+        assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
+        // insert must not panic either.
+        cache.insert(&e, &result("SIMPLE"), "complexity|m|t|x");
+    }
+}
+
+#[test]
+#[ignore] // requires a running Redis Stack at REDIS_URL (see hack/redis-stack.sh)
+fn paraphrase_hit_after_insert() {
+    let url = std::env::var("REDIS_URL").expect("REDIS_URL for the live test");
+    let cache = RedisSemanticCache::connect(&cfg(&url), Metrics::new()).expect("connect");
+    let a = Embedding::new(vec![1.0, 0.0, 0.0]);
+    let close = Embedding::new(vec![0.98, 0.02, 0.0]); // near-identical direction
+    cache.insert(&a, &result("SIMPLE"), "complexity|m|t|x");
+    std::thread::sleep(std::time::Duration::from_millis(100)); // async write-back settles
+    let hit = cache.lookup(&close, "complexity|m|t|x");
+    assert_eq!(hit.map(|r| r.ranked[0].id.clone()), Some("SIMPLE".into()));
+}
+
+#[test]
+#[ignore] // requires a running Redis Stack at REDIS_URL
+fn identity_isolates_across_revisions() {
+    let url = std::env::var("REDIS_URL").expect("REDIS_URL for the live test");
+    let cache = RedisSemanticCache::connect(&cfg(&url), Metrics::new()).expect("connect");
+    let e = Embedding::new(vec![0.0, 1.0, 0.0]);
+    cache.insert(&e, &result("SIMPLE"), "complexity|m1|t|x");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(cache.lookup(&e, "complexity|m2|t|x").is_none(), "different revision must not hit");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test redis_semantic lookup_is_fail_open_when_redis_is_unreachable`
+Expected: FAIL — unresolved import `llm_d_sc::cache::redis`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/cache/redis.rs`. Uses the pure helpers from Task 7 and the breaker from Task 6. The write path is deferred to Task 9; here `insert` may be a direct best-effort write (Task 9 makes it async). Key points: build the index on connect (idempotent — ignore "Index already exists"); store hashes under `sc:{tag}:{blake3(vector-bytes)}`; run `FT.SEARCH` KNN 1 filtered by the `identity` TAG; compare `cosine_score_from_distance(distance) >= threshold`.
+
+```rust
+//! Redis Stack (RediSearch) semantic cache. BEST-EFFORT and FAIL-OPEN: every
+//! Redis interaction is wrapped so any error/timeout yields "no hit" (lookup)
+//! or a dropped write (insert). Guarded by a circuit breaker so a dead Redis
+//! costs one probe per cooldown, not one timeout per request.
+
+use std::time::Duration;
+
+use r2d2::Pool;
+use redis::Client;
+
+use crate::cache::breaker::CircuitBreaker;
+use crate::cache::redis_codec::{
+    cosine_score_from_distance, decode_result, encode_result, index_name, vector_to_bytes,
+};
+use crate::cache::SemanticCache;
+use crate::classify::{ClassificationResult, Embedding};
+use crate::config::CacheConfig;
+use crate::metrics::Metrics;
+
+pub struct RedisSemanticCache {
+    pool: Pool<Client>,
+    threshold: f32,
+    ttl_secs: u64,
+    breaker: CircuitBreaker,
+    metrics: Metrics,
+}
+
+impl RedisSemanticCache {
+    /// Connect, size the pool small (matches the inference pool width), set
+    /// per-op timeouts, and ensure the vector index exists.
+    pub fn connect(cfg: &CacheConfig, metrics: Metrics) -> Result<RedisSemanticCache, String> {
+        let url = cfg.redis_url.as_ref().ok_or("redis-semantic requires a URL")?;
+        let client = Client::open(url.as_str()).map_err(|e| e.to_string())?;
+        let pool = Pool::builder()
+            .max_size(8)
+            .connection_timeout(Duration::from_millis(cfg.timeout_ms))
+            .build(client)
+            .map_err(|e| e.to_string())?;
+        let cache = RedisSemanticCache {
+            pool,
+            threshold: cfg.threshold,
+            ttl_secs: cfg.ttl_secs,
+            breaker: CircuitBreaker::new(5, Duration::from_secs(10)),
+            metrics,
+        };
+        // Best-effort index creation; a missing index only means lookups miss.
+        let _ = cache.ensure_index();
+        Ok(cache)
+    }
+
+    /// Create the FLAT COSINE vector index if absent. Idempotent: an
+    /// "Index already exists" error is treated as success.
+    fn ensure_index(&self) -> Result<(), String> {
+        // NOTE: dimension is discovered from the first stored vector; RediSearch
+        // requires DIM at create time, so create lazily on first insert instead
+        // (see insert). This function is a no-op placeholder kept for symmetry.
+        Ok(())
+    }
+
+    fn with_timeout_conn<T>(
+        &self,
+        f: impl FnOnce(&mut redis::Connection) -> redis::RedisResult<T>,
+    ) -> Result<T, String> {
+        let mut conn = self.pool.get().map_err(|e| e.to_string())?;
+        conn.set_read_timeout(Some(Duration::from_millis(50))).ok();
+        conn.set_write_timeout(Some(Duration::from_millis(50))).ok();
+        f(&mut conn).map_err(|e| e.to_string())
+    }
+}
+
+impl SemanticCache for RedisSemanticCache {
+    fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult> {
+        if !self.breaker.allow() {
+            return None;
+        }
+        let blob = vector_to_bytes(&embedding.vector);
+        // FT.SEARCH sc_semantic_idx "(@identity:{<tag>})=>[KNN 1 @vec $BLOB AS dist]"
+        //   PARAMS 2 BLOB <blob> DIALECT 2 SORTBY dist RETURN 2 dist payload
+        let query = format!("(@identity:{{{identity}}})=>[KNN 1 @vec $BLOB AS dist]");
+        let outcome = self.with_timeout_conn(|conn| {
+            redis::cmd("FT.SEARCH")
+                .arg(index_name())
+                .arg(&query)
+                .arg("PARAMS").arg(2).arg("BLOB").arg(blob.as_slice())
+                .arg("SORTBY").arg("dist")
+                .arg("RETURN").arg(2).arg("dist").arg("payload")
+                .arg("DIALECT").arg(2)
+                .query::<redis::Value>(conn)
+        });
+        match outcome {
+            Ok(value) => {
+                self.breaker.record_success();
+                match parse_knn_reply(&value) {
+                    Some((distance, payload)) if cosine_score_from_distance(distance) >= self.threshold => {
+                        self.metrics.record_l2_hit();
+                        decode_result(&payload)
+                    }
+                    _ => {
+                        self.metrics.record_l2_miss();
+                        None
+                    }
+                }
+            }
+            Err(_) => {
+                self.breaker.record_failure();
+                self.metrics.record_l2_degraded();
+                None
+            }
+        }
+    }
+
+    fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str) {
+        if !self.breaker.allow() {
+            return;
+        }
+        let blob = vector_to_bytes(&embedding.vector);
+        let dim = embedding.dim();
+        let payload = encode_result(result);
+        let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
+        let ttl = self.ttl_secs;
+        let outcome = self.with_timeout_conn(move |conn| {
+            // Create the index lazily now that we know the dimension. Ignore the
+            // "already exists" error via a best-effort call.
+            let _ = redis::cmd("FT.CREATE")
+                .arg(index_name())
+                .arg("ON").arg("HASH")
+                .arg("PREFIX").arg(1).arg("sc:")
+                .arg("SCHEMA")
+                .arg("identity").arg("TAG")
+                .arg("payload").arg("TEXT")
+                .arg("vec").arg("VECTOR").arg("FLAT").arg(6)
+                .arg("TYPE").arg("FLOAT32")
+                .arg("DIM").arg(dim)
+                .arg("DISTANCE_METRIC").arg("COSINE")
+                .query::<redis::Value>(conn);
+            redis::cmd("HSET")
+                .arg(&key)
+                .arg("identity").arg(identity)
+                .arg("payload").arg(&payload)
+                .arg("vec").arg(blob.as_slice())
+                .query::<redis::Value>(conn)?;
+            redis::cmd("EXPIRE").arg(&key).arg(ttl).query::<redis::Value>(conn)
+        });
+        match outcome {
+            Ok(_) => self.breaker.record_success(),
+            Err(_) => {
+                self.breaker.record_failure();
+                self.metrics.record_l2_degraded();
+            }
+        }
+    }
+}
+
+/// Extract (distance, payload) from a RediSearch FT.SEARCH reply, or None if the
+/// reply shape is empty/unexpected. Fail-open: any parse surprise is a miss.
+fn parse_knn_reply(value: &redis::Value) -> Option<(f32, String)> {
+    // FT.SEARCH returns: [count, key, [field, val, field, val, ...], ...]
+    if let redis::Value::Bulk(items) = value {
+        // items[0] = count; the field array is the 3rd element (index 2).
+        if let Some(redis::Value::Bulk(fields)) = items.get(2) {
+            let mut dist: Option<f32> = None;
+            let mut payload: Option<String> = None;
+            let mut i = 0;
+            while i + 1 < fields.len() {
+                let name = as_string(&fields[i]);
+                let val = as_string(&fields[i + 1]);
+                match name.as_deref() {
+                    Some("dist") => dist = val.and_then(|s| s.parse::<f32>().ok()),
+                    Some("payload") => payload = val,
+                    _ => {}
+                }
+                i += 2;
+            }
+            if let (Some(d), Some(p)) = (dist, payload) {
+                return Some((d, p));
+            }
+        }
+    }
+    None
+}
+
+fn as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::Data(bytes) => Some(String::from_utf8_lossy(bytes).into_owned()),
+        redis::Value::Status(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+```
+
+Add `pub mod redis;` to `src/cache.rs`. Ensure `lib.rs` exposes `pub mod cache;` (already does) so `llm_d_sc::cache::redis` resolves.
+
+> Note on the `redis` crate version: `cargo add` pins the current release. If the installed version renames `redis::Value::Bulk`/`Data` (newer versions use `Array`/`BulkString`), update `parse_knn_reply`/`as_string` to the variants your `Cargo.lock` shows — run `cargo doc -p redis --open` to confirm the enum. The logic is unchanged.
+
+- [ ] **Step 4: Run the fail-open unit test + full build**
+
+Run: `cargo test --test redis_semantic lookup_is_fail_open_when_redis_is_unreachable && cargo build`
+Expected: PASS / builds. (The two `#[ignore]`d live tests are skipped.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cache.rs src/cache/redis.rs tests/redis_semantic.rs Cargo.toml Cargo.lock
+git commit -s -m "feat(cache): add fail-open RedisSemanticCache (KNN lookup + lazy index)"
+```
+
+---
+
+### Task 9: Async fire-and-forget write-back
+
+Move `insert`'s Redis write off the caller's thread onto a bounded channel + a background worker, so the inference thread returns immediately and a burst of misses can never block on Redis.
+
+**Files:**
+- Modify: `src/cache/redis.rs`
+- Test: `tests/redis_semantic.rs` (add a non-ignored test that `insert` returns promptly even against a dead Redis)
+
+**Interfaces:**
+- Unchanged public surface (`insert` signature stays). Internally spawns one worker thread and holds a `std::sync::mpsc::SyncSender<WriteJob>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn insert_returns_immediately_even_when_redis_is_down() {
+    let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), Metrics::new());
+    if let Ok(cache) = cache {
+        let e = Embedding::new(vec![0.1, 0.2, 0.3]);
+        let start = std::time::Instant::now();
+        for _ in 0..100 {
+            cache.insert(&e, &result("SIMPLE"), "complexity|m|t|x");
+        }
+        assert!(start.elapsed() < std::time::Duration::from_millis(200),
+            "100 inserts must not block on Redis; write-back is async");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test redis_semantic insert_returns_immediately_even_when_redis_is_down`
+Expected: FAIL — synchronous inserts each pay the connection timeout (~50ms × 100).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a write channel and worker. Keep the actual Redis write logic (from Task 8's `insert`) in a private `fn write_now(&…)`; `insert` now just enqueues.
+
+```rust
+enum WriteJob {
+    Put { blob: Vec<u8>, dim: usize, payload: String, identity: String },
+}
+
+// In the struct:
+//   writer: std::sync::mpsc::SyncSender<WriteJob>,
+
+// In connect(), after building `cache` fields, spawn the worker with a clone of
+// the pool/breaker/metrics/ttl and a bounded channel (capacity 1024). On a full
+// channel, `try_send` drops the job (best-effort). The worker loops on recv and
+// performs the HSET/EXPIRE (+ lazy FT.CREATE) exactly as Task 8's insert did.
+```
+
+Concretely, replace `insert`:
+
+```rust
+fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str) {
+    let job = WriteJob::Put {
+        blob: vector_to_bytes(&embedding.vector),
+        dim: embedding.dim(),
+        payload: encode_result(result),
+        identity: identity.to_string(),
+    };
+    // Best-effort: a full queue drops the write rather than blocking the caller.
+    let _ = self.writer.try_send(job);
+}
+```
+
+And in `connect`, build the channel + worker:
+
+```rust
+let (tx, rx) = std::sync::mpsc::sync_channel::<WriteJob>(1024);
+{
+    let pool = pool.clone();
+    let breaker_metrics = metrics.clone();
+    let ttl = cfg.ttl_secs;
+    std::thread::Builder::new()
+        .name("sc-l2-writeback".into())
+        .spawn(move || {
+            let breaker = CircuitBreaker::new(5, Duration::from_secs(10));
+            for job in rx {
+                if !breaker.allow() { continue; }
+                let WriteJob::Put { blob, dim, payload, identity } = job;
+                let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
+                let write = (|| -> Result<(), String> {
+                    let mut conn = pool.get().map_err(|e| e.to_string())?;
+                    conn.set_write_timeout(Some(Duration::from_millis(50))).ok();
+                    let _ = redis::cmd("FT.CREATE")
+                        .arg(index_name()).arg("ON").arg("HASH")
+                        .arg("PREFIX").arg(1).arg("sc:").arg("SCHEMA")
+                        .arg("identity").arg("TAG").arg("payload").arg("TEXT")
+                        .arg("vec").arg("VECTOR").arg("FLAT").arg(6)
+                        .arg("TYPE").arg("FLOAT32").arg("DIM").arg(dim)
+                        .arg("DISTANCE_METRIC").arg("COSINE")
+                        .query::<redis::Value>(&mut conn);
+                    redis::cmd("HSET").arg(&key)
+                        .arg("identity").arg(&identity)
+                        .arg("payload").arg(&payload)
+                        .arg("vec").arg(blob.as_slice())
+                        .query::<redis::Value>(&mut conn).map_err(|e| e.to_string())?;
+                    redis::cmd("EXPIRE").arg(&key).arg(ttl)
+                        .query::<redis::Value>(&mut conn).map_err(|e| e.to_string())?;
+                    Ok(())
+                })();
+                match write {
+                    Ok(_) => breaker.record_success(),
+                    Err(_) => { breaker.record_failure(); breaker_metrics.record_l2_degraded(); }
+                }
+            }
+        })
+        .map_err(|e| e.to_string())?;
+}
+// add `writer: tx,` to the returned struct literal.
+```
+
+Remove the now-duplicated write body from the `SemanticCache::insert` in Task 8 (only the enqueue remains). Keep `lookup` as-is.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test redis_semantic insert_returns_immediately_even_when_redis_is_down && cargo test --test redis_semantic lookup_is_fail_open_when_redis_is_unreachable`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cache/redis.rs tests/redis_semantic.rs
+git commit -s -m "feat(cache): async fire-and-forget L2 write-back with bounded queue"
+```
+
+---
+
+### Task 10: L2 metrics counters
+
+**Files:**
+- Modify: `src/metrics.rs`
+- Test: `src/metrics.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces on `Metrics`: `record_l2_hit()`, `record_l2_miss()`, `record_l2_degraded()`, and a snapshot exposing `l2_hits`, `l2_misses`, `l2_degraded`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn l2_counters_increment_independently() {
+    let m = Metrics::new();
+    m.record_l2_hit();
+    m.record_l2_hit();
+    m.record_l2_miss();
+    m.record_l2_degraded();
+    let s = m.snapshot();
+    assert_eq!(s.l2_hits, 2);
+    assert_eq!(s.l2_misses, 1);
+    assert_eq!(s.l2_degraded, 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib metrics::tests::l2_counters_increment_independently`
+Expected: FAIL — `no method named record_l2_hit`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Follow the existing counter pattern in `src/metrics.rs` (mirror how `record_cache_hit`/`record_cache_miss` and the snapshot fields are implemented there — same `AtomicU64` + snapshot struct field style). Add three `AtomicU64` counters, three `record_l2_*` methods, and three `l2_*` fields on the snapshot struct.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --lib metrics::tests::l2_counters_increment_independently`
+Expected: PASS. Then `cargo build` to confirm `src/cache/redis.rs`'s `record_l2_*` calls resolve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metrics.rs
+git commit -s -m "feat(metrics): add L2 hit/miss/degraded counters"
+```
+
+---
+
+### Task 11: Select the cache strategy in the server binary
+
+Wire `CacheConfig::from_env()` into `src/bin/server.rs`: when `strategy == "redis-semantic"`, build a `RedisSemanticCache` and construct the core with `ServiceCore::with_semantic_cache`; otherwise use the default (exact/Noop). A Redis connect failure at startup must NOT crash the server — log and fall back to exact (fail-open extends to boot).
+
+**Files:**
+- Modify: `src/bin/server.rs`
+- Test: manual smoke (documented below) — the binary path is not unit-tested in this repo; the wiring is covered by Tasks 4/5/8 unit tests.
+
+**Interfaces:**
+- Consumes: `CacheConfig::from_env`, `RedisSemanticCache::connect`, `ServiceCore::with_semantic_cache`.
+
+- [ ] **Step 1: Read the current core construction**
+
+Run: `grep -n "ServiceCore" src/bin/server.rs`
+Identify where the core is built around the loaded `CandleClassifier` and the shared `Metrics`.
+
+- [ ] **Step 2: Implement strategy selection**
+
+At core construction, replace the single `ServiceCore::with_metrics(classifier, metrics)` call with:
+
+```rust
+let cache_cfg = llm_d_sc::config::CacheConfig::from_env()
+    .unwrap_or_else(|e| {
+        eprintln!("invalid cache config ({e:?}); falling back to exact cache");
+        llm_d_sc::config::CacheConfig {
+            strategy: "exact".into(), redis_url: None,
+            threshold: 0.90, ttl_secs: 86_400, timeout_ms: 50,
+        }
+    });
+let core = if cache_cfg.strategy == "redis-semantic" {
+    match llm_d_sc::cache::redis::RedisSemanticCache::connect(&cache_cfg, metrics.clone()) {
+        Ok(rc) => {
+            eprintln!("semantic cache enabled (redis-semantic, threshold {})", cache_cfg.threshold);
+            llm_d_sc::classify::ServiceCore::with_semantic_cache(
+                classifier, metrics.clone(), std::sync::Arc::new(rc),
+            )
+        }
+        Err(e) => {
+            eprintln!("redis-semantic unavailable ({e}); falling back to exact cache");
+            llm_d_sc::classify::ServiceCore::with_metrics(classifier, metrics.clone())
+        }
+    }
+} else {
+    llm_d_sc::classify::ServiceCore::with_metrics(classifier, metrics.clone())
+};
+```
+
+Match the actual variable names in `server.rs` (`classifier`, `metrics`) discovered in Step 1.
+
+- [ ] **Step 3: Verify it builds and the default path is unchanged**
+
+Run: `cargo build --bin llm-d-sc-server && cargo test`
+Expected: builds; full suite green (default = exact, no behavior change).
+
+- [ ] **Step 4: Manual smoke (optional, requires Redis Stack)**
+
+```bash
+# terminal 1
+docker run --rm -p 6379:6379 redis/redis-stack-server:latest
+# terminal 2
+LLM_D_SC_CACHE=redis-semantic LLM_D_SC_REDIS_URL=redis://127.0.0.1:6379 \
+  cargo run --bin llm-d-sc-server
+# expect log: "semantic cache enabled (redis-semantic, threshold 0.9)"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bin/server.rs
+git commit -s -m "feat(server): select cache strategy from env, fall back to exact on Redis failure"
+```
+
+---
+
+### Task 12: Documentation + dev helper
+
+**Files:**
+- Modify: `README.md` (configuration section — add the `LLM_D_SC_CACHE*` env vars table)
+- Create: `hack/redis-stack.sh` (starts a local Redis Stack for the `#[ignore]`d tests)
+- Modify: `docs/` architecture doc if one enumerates the cache (search: `grep -rn "exact-result cache" docs/`)
+
+**Interfaces:** none (docs/tooling).
+
+- [ ] **Step 1: Write `hack/redis-stack.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Start a local Redis Stack (RediSearch) for the semantic-cache integration tests.
+set -euo pipefail
+exec docker run --rm -p 6379:6379 redis/redis-stack-server:latest
+```
+
+Make it executable: `chmod +x hack/redis-stack.sh`
+
+- [ ] **Step 2: Document the env vars in `README.md`**
+
+Add a subsection describing the toggle, defaults, and Redis Stack requirement, matching the env-var table in the spec (`docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md` §7). Include the one-liner to run the live tests:
+
+```bash
+./hack/redis-stack.sh &   # start Redis Stack
+REDIS_URL=redis://127.0.0.1:6379 cargo test --test redis_semantic -- --ignored
+```
+
+- [ ] **Step 3: Verify docs build/links**
+
+Run: `cargo test --doc` (no doctests expected to break) and re-read the edited README section for accuracy against the implemented env-var names.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md hack/redis-stack.sh docs/
+git commit -s -m "docs: document semantic cache toggle + add Redis Stack dev helper"
+```
+
+---
+
+### Task 13: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Default path — no regression, no Redis**
+
+Run: `cargo test`
+Expected: all non-`#[ignore]` tests pass, including the existing `u040/u041/u070/u071` cache tests and the new Task 1-10 tests.
+
+- [ ] **Step 2: Lints/format match repo standards**
+
+Run: `cargo fmt --check && cargo clippy --all-targets -- -D warnings`
+Expected: clean (fix any clippy findings in the new modules).
+
+- [ ] **Step 3: Live semantic path (requires Redis Stack)**
+
+Run:
+```bash
+./hack/redis-stack.sh &
+REDIS_URL=redis://127.0.0.1:6379 cargo test --test redis_semantic -- --ignored
+```
+Expected: `paraphrase_hit_after_insert` and `identity_isolates_across_revisions` pass.
+
+- [ ] **Step 4: Parity guard (requires model weights, if available)**
+
+Run: `./hack/test-parity` (or `cargo test -- --ignored` after `./hack/fetch-model`)
+Expected: `service_core_production_candle_cache_hit_zero_tokenizer_zero_forward` still passes — proving the embed/rank split preserved the miss=1/hit=0 counter contract.
+
+- [ ] **Step 5: Final commit (if any lint fixes were needed)**
+
+```bash
+git add -A
+git commit -s -m "chore: clippy/fmt cleanup for semantic cache tier"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Off-by-default toggle + registry → Task 5, Task 11. ✓
+- Two-stage embed/rank (embed once) → Task 1, Task 2. ✓
+- `SemanticCache` trait + Noop default → Task 3; wired in Task 4. ✓
+- L1→embed→L2→rank→write-back data flow → Task 4 (orchestration), Task 8 (lookup), Task 9 (async write). ✓
+- Cache-identity isolation (TAG) → Task 3 (`identity_tag`), Task 8 (TAG filter), integration test in Task 8. ✓
+- Fail-open + circuit breaker (pre-mortem #1) → Task 6, Task 8, Task 9, Task 11 (boot fallback). ✓
+- TTL + eviction (pre-mortem #3) → Task 8/9 (`EXPIRE`); Redis `maxmemory`/`allkeys-lru` documented in Task 12/spec (operator config, not code). ✓
+- FLAT COSINE index, LE f32 blob → Task 7, Task 8. ✓
+- Metrics (hit/miss/degrade) → Task 10; consumed in Task 8/9. ✓
+- Threshold τ default 0.90, TTL 24h, timeout 50ms → Task 5. ✓
+- No-regression when off → Task 2 Step 4, Task 4 Step 4, Task 13 Step 1. ✓
+
+**Placeholder scan:** The only intentionally-descriptive step is Task 10 Step 3 ("mirror the existing counter pattern") and Task 11 (grep-then-edit the binary) — both reference concrete existing patterns the engineer reads in-repo, with exact method names/behavior specified. `ensure_index` is a deliberate no-op (documented why: DIM is known only at first insert). No `TODO`/`TBD`/"add error handling" left.
+
+**Type consistency:** `Embedding`/`Embedding::new`/`dim` (Task 1) used identically in Tasks 2/3/4/7/8/9. `SemanticCache::lookup/insert` signatures (Task 3) match all impls (Noop Task 3, Redis Task 8/9) and the ServiceCore call site (Task 4). `identity_tag` output ("c|m|t|x") matches the TAG filter and the test fixtures across Tasks 3/4/8. `CacheConfig` fields (Task 5) match `RedisSemanticCache::connect` and `server.rs` (Tasks 8/11). `record_l2_hit/miss/degraded` (Task 10) match the calls in Tasks 8/9.

--- a/docs/superpowers/semantic-cache-stakeholder-overview.md
+++ b/docs/superpowers/semantic-cache-stakeholder-overview.md
@@ -1,0 +1,118 @@
+# Semantic Cache Classifier — Stakeholder Overview
+
+*A plain-language summary of the change, for a non-implementation audience.*
+
+## The one-sentence version
+
+We are adding an **optional, off-by-default "semantic cache"** so that prompts
+that *mean the same thing* reuse a previously computed label — instead of only
+reusing labels for prompts that are **character-for-character identical**.
+
+## What we have today vs. what we're adding
+
+Today the classifier has a **1:1 (exact) cache**: it only reuses a result when a
+new prompt is *byte-for-byte identical* to one it saw before. Reword the prompt
+even slightly and it's treated as brand new.
+
+The new tier adds **meaning-based reuse** on top of that, backed by Redis.
+
+```mermaid
+flowchart LR
+    subgraph Today["Today — exact cache only"]
+        A1["what is the capital of France"] -->|exact match| C1[("cache")]
+        A2["what is the capital of Japan"] -.->|NO match<br/>(different text)| C1
+        A2 --> R1["run classifier again"]
+    end
+
+    subgraph New["With semantic cache"]
+        B1["what is the capital of France"] -->|stored: SIMPLE| C2[("Redis<br/>semantic cache")]
+        B2["what is the capital of Japan"] -->|close in meaning| C2
+        C2 -->|reuse: SIMPLE| B2
+    end
+```
+
+## The worked example (the France → Japan story)
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant SC as Classifier
+    participant R as Redis (semantic cache)
+
+    Note over U,R: First time we see this kind of question
+    U->>SC: "what is the capital of France"
+    SC->>SC: understand the prompt (embed) + label it
+    SC->>R: store {meaning ➜ label: SIMPLE}
+    SC-->>U: SIMPLE
+
+    Note over U,R: A reworded, similar question arrives later
+    U->>SC: "what is the capital of Japan"
+    SC->>SC: understand the prompt (embed)
+    SC->>R: any stored meaning close to this?
+    R-->>SC: yes — SIMPLE (very similar)
+    SC-->>U: SIMPLE  ✅ reused, no re-labeling
+```
+
+**Plain English:** the first question is labeled `SIMPLE` and its *meaning* is
+remembered. The second question is different words but the same kind of ask, so
+the system recognizes it's close and returns `SIMPLE` from the cache.
+
+## What this buys us
+
+| Benefit | What it means for stakeholders |
+|---|---|
+| **Higher reuse ("hit rate")** | Reworded / paraphrased prompts now reuse labels instead of being re-processed. |
+| **Persistence & sharing** | Labels live in Redis, so they survive restarts and can be shared — unlike today's memory-only cache that's lost on restart. |
+| **Consistency** | Similar prompts get the same label, reducing "why did these two similar prompts get labeled differently?" surprises. |
+
+## What it is *not* (setting expectations honestly)
+
+- It is **off by default.** Nothing changes for existing deployments until we
+  explicitly turn it on. Turning it off is a single setting.
+- It is **not a correctness guarantee.** Two prompts that look similar could
+  occasionally get the same label when they arguably shouldn't. For our use case
+  (labels are advisory), that trade-off is acceptable and tunable via a
+  similarity threshold.
+- It does **not** remove the core work of understanding a prompt — that step
+  still runs. The saving is on the *labeling* step and, more importantly, the
+  *reuse* and *consistency* across similar prompts.
+
+## Reliability — "what if Redis goes down?"
+
+This is designed so **Redis can never take the classifier down**. Redis is a
+best-effort accelerator, not a dependency.
+
+```mermaid
+flowchart TD
+    Q["Prompt arrives"] --> E["Understand the prompt"]
+    E --> L{"Redis available<br/>& has a close match?"}
+    L -->|Yes| H["Reuse stored label ✅"]
+    L -->|"No / Redis slow / Redis down"| F["Just label it normally ✅"]
+    F --> S["(best-effort) remember it for next time"]
+```
+
+If Redis is slow or unavailable, the system automatically **falls back to
+labeling normally** — with a safety switch (a "circuit breaker") that stops
+even trying Redis for a short cool-down, so an outage never slows every request.
+
+## How we control it
+
+| Control | Purpose |
+|---|---|
+| On/off switch | Enable or disable the whole semantic tier (default: **off**). |
+| Similarity threshold | How "close in meaning" two prompts must be to count as a match — higher = safer/fewer reuses, lower = more reuses. |
+| Expiry (TTL) | Cached labels automatically age out so the cache stays fresh and bounded. |
+
+## Rollout shape
+
+1. Ship it **off by default** — zero change to current behavior, fully verified.
+2. Turn it on in a **single, moderate-scale service** with one Redis, watch the
+   reuse rate and a sample of label quality.
+3. Tune the similarity threshold from real traffic.
+4. If we ever outgrow this, the Redis piece is behind a clean seam, so moving to
+   a larger/shared setup later is a swap, not a rewrite.
+
+## Where the detail lives
+
+- **Design rationale & trade-offs:** `docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md`
+- **Step-by-step build plan:** `docs/superpowers/plans/2026-08-30-semantic-cache-classifier.md`

--- a/docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md
+++ b/docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md
@@ -1,0 +1,181 @@
+# Semantic Cache Classifier — Design
+
+**Date:** 2026-08-30
+**Status:** Approved design (pre-implementation)
+**Related (existing, stubbed):** `specs/0.22-cache-session/spec.md`, `specs/0.24-runtime-pluggability/spec.md`
+
+## 1. Summary
+
+Add an **optional, pluggable semantic cache** to the classifier so that
+semantically-similar prompts reuse a previously computed label without re-ranking.
+Example: `"what is the capital of France"` → `simple`; a later
+`"what is the capital of Japan"` is close in embedding space and returns `simple`
+from the cache.
+
+The semantic tier is a **best-effort optimization layer**, off by default, backed by
+Redis (RediSearch vector index). It sits alongside — not in place of — the existing
+in-memory exact (1:1) cache. Classification never fails because of the cache.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Maximize **paraphrase hit-rate**: semantically equivalent prompts get the same label.
+- **Persistence & sharing** of labels via Redis (survive restarts, shareable across future replicas).
+- **Toggleable plugin**: off by default; enabled by config. Zero cost when off.
+- **Fail-open**: Redis unavailable/slow ⇒ degrade to compute; never error the request.
+
+**Non-goals (YAGNI at current scale)**
+- Not a standalone cache microservice (documented as the future scale-out path).
+- Not reducing embedding compute — the embedding (BERT forward) is unavoidable on a
+  lookup and is explicitly *not* what this saves. This tier saves the (cheap) ranking
+  step; its value is hit-rate, persistence, and label stability.
+- No strong correctness guarantees on false-positive similarity hits (wrong labels are
+  tolerable per the routing use case); bounded only by threshold + TTL.
+
+## 3. Context (as-built)
+
+- Rust crate `llm-d-sc`. Embedding-based nearest-anchor ranker (not a trained head).
+  Every forward computes a **mean-pooled, L2-normalized BERT embedding**
+  (`src/embedding.rs`) — exactly the vector a cosine KNN needs.
+- Plugin seam already exists: everything is generic over the `ClassifierRuntime` trait
+  (`src/classify.rs`).
+- Current "1:1 cache": `ExactCache`/`SharedCache` (`src/cache.rs`) — in-memory
+  `HashMap` keyed by a **BLAKE3** fingerprint over
+  `classifier_id + model_rev + tokenizer_rev + taxonomy_rev + normalized_text`,
+  FIFO eviction (cap 50k), single-flight coalescing. Lives in the `ServiceCore<R>`
+  wrapper (`src/classify.rs`), so all backends inherit caching.
+- No Redis, no vector store today — this is net-new.
+- Config: env vars (live) + a TOML `Config` with a `KNOWN_BACKENDS` registry pattern
+  (`src/config.rs`).
+
+## 4. Chosen approach — Two-stage runtime seam + pluggable cache tier
+
+The semantic lookup needs the embedding, but the exact cache keys on text *before*
+embedding. So the runtime forward is split so the cache layer can interpose between
+embed and rank.
+
+### 4.1 Data flow
+
+```
+Classify(req)
+  └─ ServiceCore::classify
+       1. L1 exact  (BLAKE3 text key)            ── hit ─▶ return   (in-memory, fastest)
+       2. embed(input)                            ── the one unavoidable BERT forward
+       3. L2 semantic KNN(vector, filter=identity, τ)
+                                                  ── hit ─▶ return stored label (skip rank)
+       4. rank(embedding)                         ── miss path only
+       5. write-back:  L1 sync,  L2 fire-and-forget (bounded channel → bg task)
+```
+
+Disciplines carried from the exact cache:
+- **Cache-identity isolation:** L2 entries carry a TAG of
+  `classifier_id + model_rev + tokenizer_rev + taxonomy_rev`; a KNN query filters on it.
+  A revision bump can never serve a stale label (mirrors the BLAKE3 identity fields).
+- **Embed once:** step 2 feeds both step 3 and step 4.
+- **Writes never block:** step 5's Redis write goes through a bounded channel to a
+  background task; the inference thread returns immediately. On a full channel, the
+  write is dropped (best-effort).
+
+### 4.2 Architectural pattern
+
+Layered **two-tier cache** (L1 in-process exact / L2 shared semantic) behind a
+**strategy interface**, inside the existing modular monolith. Not microservices, not
+event-driven. Redis is a best-effort cache, never a source of truth ⇒ fail-open by
+construction.
+
+## 5. Components
+
+| Component | Responsibility | Input → Output | Location |
+|---|---|---|---|
+| `ClassifierRuntime` (split) | Two composable steps | `embed(Input) → Embedding`; `rank(&Embedding, &Input) → Result` | `src/classify.rs` |
+| `Embedding` | Value type: L2-normalized vector + revisions | — | `src/embedding.rs` |
+| `SemanticCache` (new trait) | Pluggable L2 lookup/insert seam | `lookup(&Embedding) → Option<Hit>`; `insert(&Embedding, &Result)` | `src/cache.rs` |
+| `NoopSemanticCache` | Default when off (zero-cost) | always miss | `src/cache.rs` |
+| `RedisSemanticCache` | Vector KNN; fail-open; async write-back; circuit breaker | embedding → nearest label ≥ τ | new `src/cache/redis.rs` |
+| `ServiceCore<R>` | Orchestrates L1→embed→L2→rank→write | Input → Result | `src/classify.rs` |
+| `ExactCache`/`SharedCache` (L1) | Unchanged — exact hits + single-flight | text hash → Result | `src/cache.rs` |
+| Cache config + registry | Select strategy, τ, Redis URL, TTL; validate | env/TOML → `CacheConfig` | `src/config.rs` |
+| Metrics | L1/L2 hit-rate, KNN latency, degrade/breaker count, τ-reject | counters/histograms | `src/metrics.rs` |
+
+## 6. Redis representation
+
+- **Redis Stack / Redis 8+** (RediSearch vector index). MVP index type: **`FLAT`**,
+  distance **COSINE** (embeddings are already L2-normalized) — exact KNN, simplest.
+  `HNSW` is the documented scale lever if the entry set grows large.
+- Per entry (hash): `embedding` (vector field), `ranked` (JSON of labels+scores),
+  revision fields, `identity` (TAG), `created_at`, `hit_count`. Per-entry **TTL**.
+- Query: `KNN 1` over the vector field, filtered by `identity` TAG; accept if
+  best cosine similarity ≥ τ.
+- Eviction: entry TTL + Redis `maxmemory` with `allkeys-lru`. Cache is disposable ⇒
+  eviction always safe.
+
+## 7. Configuration & toggle
+
+Off by default. Extends the existing registry/validation pattern in `src/config.rs`.
+
+| Setting | Env | Default |
+|---|---|---|
+| Strategy | `LLM_D_SC_CACHE` = `exact` \| `redis-semantic` | `exact` |
+| Redis URL | `LLM_D_SC_REDIS_URL` | (required if `redis-semantic`) |
+| Similarity threshold τ | `LLM_D_SC_CACHE_THRESHOLD` | `0.90` (tunable; hit-rate-favoring) |
+| Entry TTL | `LLM_D_SC_CACHE_TTL` | `86400s` |
+| Redis op timeout | `LLM_D_SC_CACHE_TIMEOUT_MS` | `50` |
+
+Validation mirrors `KNOWN_BACKENDS`: unknown strategy rejected; `redis-semantic`
+requires a URL.
+
+## 8. Failure modes & pre-mortem
+
+Only new SPOF is Redis, **contained to L2**: every Redis failure degrades to
+"L1 + compute". Redis is a performance SPOF, not an availability SPOF.
+
+| # | Failure | Mitigation |
+|---|---|---|
+| 1 | Redis slow/unreachable stalls inference thread | Tight per-op timeout + fail-open; **circuit breaker** skips L2 for a cooldown after N consecutive errors |
+| 2 | False-positive semantic hit (wrong label) | τ threshold (per-taxonomy capable); tolerable per use case; TTL ages out bad entries |
+| 3 | Unbounded growth | Per-entry TTL + `maxmemory`/`allkeys-lru` |
+| 4 | Stale labels after model/taxonomy bump | Identity TAG filter — new revisions never match old entries; no manual flush |
+| 5 | Write-back backpressure | Bounded channel; drop write on full (best-effort) |
+| 6 | Poisoned/garbage vectors | Validate vector dim on read; skip+delete malformed, treat as miss |
+| 7 | Index cold start | Warms naturally; no correctness impact |
+
+Watch hardest: **#1** (circuit breaker is non-optional) and **#2** (monitor L2 hit-rate
+vs. sampled label-correctness to tune τ).
+
+## 9. Trade-off matrix
+
+Recommended = **A: in-process two-tier behind a strategy trait.**
+Alternative = **B: standalone semantic-cache microservice/sidecar.**
+
+| Dimension | A (recommended) | B (standalone service) |
+|---|---|---|
+| Scalability | Great at moderate scale; L2 already shareable. Ceiling: KNN on inference thread. | Higher ceiling, unneeded now; extra hop eats savings. |
+| Complexity | Low — reuses `ServiceCore` seam + existing embedding; one trait, one module. | High — new service, contract, deploy, monitoring. |
+| Maintainability | High — one crate, one config surface, existing patterns. | Lower — cross-version drift. |
+| Latency (hit) | L1 µs; L2 one local Redis RTT. | Extra service hop. |
+| Fault tolerance | Fail-open to compute. | Same, more parts to fail. |
+| Ops cost | One opt-in Redis dependency. | Redis + a service. |
+
+**Verdict:** A wins at the stated scale. Because Redis is hidden behind the
+`SemanticCache` trait, migrating to B later is an implementation swap, not a rewrite.
+
+## 10. Testing strategy
+
+- **Unit:** `NoopSemanticCache` always-miss; `SemanticCache` trait contract; config
+  parsing/validation (unknown strategy, missing URL); τ threshold accept/reject;
+  identity-TAG isolation across revisions.
+- **Fail-open:** Redis unreachable / timeout / malformed entry ⇒ request still succeeds
+  via compute; circuit breaker opens after N errors and short-circuits L2.
+- **Integration (feature-gated / dockerized Redis Stack):** insert then paraphrase-hit;
+  exact-repeat served by L1 not L2; revision bump ⇒ miss; TTL expiry ⇒ miss.
+- **No regression when off:** default `exact` path behaves exactly as today (embed once,
+  existing single-flight and FIFO intact).
+
+## 11. Open items for the implementation plan
+
+- Exact wire shape of the split `ClassifierRuntime` (associated `Embedding` type vs.
+  concrete) and how `CandleClassifier`'s existing embed/rank internals are extracted.
+- Redis client choice + connection pooling; where the (bounded, timed) KNN call runs
+  relative to the inference pool.
+- Circuit-breaker parameters (error count, cooldown).
+- Whether τ/TTL become per-taxonomy now or stay global for MVP (default: global).

--- a/hack/playground
+++ b/hack/playground
@@ -67,6 +67,14 @@ if command -v docker >/dev/null 2>&1; then
     [ "$ready" -eq 1 ] && log "Redis ready." \
       || { warn "Redis did not become ready; falling back to L1-exact only."; CACHE_STRATEGY="exact"; }
   fi
+
+  # Start every session with an empty cache. A reused Redis container can hold
+  # cached entries from a previous run, which would make the first prompts read
+  # as hits instead of a clean compute miss — flush so the demo starts fresh.
+  if [ "$CACHE_STRATEGY" = "redis-semantic" ]; then
+    log "flushing Redis for a clean cache…"
+    docker exec "$REDIS_NAME" redis-cli FLUSHALL >/dev/null 2>&1 || true
+  fi
 else
   warn "docker not found — running L1-exact only (no semantic hits to demo)."
   warn "Install Docker and re-run to see L2 semantic hits."

--- a/hack/playground
+++ b/hack/playground
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Launch the interactive semantic-cache playground: a local web UI over the real
+# classifier + L1/L2 cache. One command that installs what it can, starts Redis
+# Stack, downloads the model if missing, builds the demo binary, and serves it.
+#
+# Usage:
+#   ./hack/playground                 # docker Redis + complexity model, UI on :8080
+#   LLM_D_SC_PLAYGROUND_ADDR=127.0.0.1:9000 ./hack/playground
+#   LLM_D_SC_CLASSIFIER=sensitivity ./hack/playground
+#
+# Requirements it checks for you: a Rust toolchain >= 1.80 (the redis-semantic
+# feature), Docker (for Redis Stack), and Python 3 + huggingface_hub (one-time
+# ~90MB model download; installed via pip if missing).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CLASSIFIER="${LLM_D_SC_CLASSIFIER:-complexity}"
+MODEL_DIR="${LLM_D_SC_MODEL_DIR:-artifacts/models/${CLASSIFIER}}"
+UI_ADDR="${LLM_D_SC_PLAYGROUND_ADDR:-127.0.0.1:8080}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+REDIS_URL="${LLM_D_SC_REDIS_URL:-redis://127.0.0.1:${REDIS_PORT}}"
+REDIS_NAME="llm-d-sc-playground-redis"
+STARTED_REDIS=0
+
+log()  { printf '\033[36m[playground]\033[0m %s\n' "$*"; }
+warn() { printf '\033[33m[playground]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31m[playground]\033[0m %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [ "$STARTED_REDIS" -eq 1 ]; then
+    log "stopping Redis ($REDIS_NAME)…"
+    docker stop "$REDIS_NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# --- Rust toolchain ---------------------------------------------------------
+command -v cargo >/dev/null 2>&1 || die "cargo not found. Install Rust >= 1.80 (https://rustup.rs)."
+
+# --- Redis Stack (semantic L2 tier) -----------------------------------------
+CACHE_STRATEGY="redis-semantic"
+if command -v docker >/dev/null 2>&1; then
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$REDIS_NAME"; then
+    log "Redis already running ($REDIS_NAME); reusing it."
+  else
+    # Clean up any stopped leftover with the same name, then start detached.
+    docker rm -f "$REDIS_NAME" >/dev/null 2>&1 || true
+    log "starting Redis Stack on port $REDIS_PORT…"
+    if docker run -d --rm --name "$REDIS_NAME" -p "${REDIS_PORT}:6379" \
+        redis/redis-stack-server:latest >/dev/null; then
+      STARTED_REDIS=1
+    else
+      warn "could not start Redis; the demo will run L1-exact only (no semantic hits)."
+      CACHE_STRATEGY="exact"
+    fi
+  fi
+
+  if [ "$CACHE_STRATEGY" = "redis-semantic" ]; then
+    log "waiting for Redis to accept connections…"
+    ready=0
+    for _ in $(seq 1 30); do
+      if docker exec "$REDIS_NAME" redis-cli ping 2>/dev/null | grep -q PONG; then
+        ready=1; break
+      fi
+      sleep 1
+    done
+    [ "$ready" -eq 1 ] && log "Redis ready." \
+      || { warn "Redis did not become ready; falling back to L1-exact only."; CACHE_STRATEGY="exact"; }
+  fi
+else
+  warn "docker not found — running L1-exact only (no semantic hits to demo)."
+  warn "Install Docker and re-run to see L2 semantic hits."
+  CACHE_STRATEGY="exact"
+fi
+
+# --- Model artifact ---------------------------------------------------------
+if [ ! -s "${MODEL_DIR}/model.safetensors" ]; then
+  log "model not found in ${MODEL_DIR}; fetching '${CLASSIFIER}' (~90MB, one-time)…"
+  command -v python3 >/dev/null 2>&1 || die "python3 not found; needed to download the model."
+  if ! python3 -c 'import huggingface_hub' >/dev/null 2>&1; then
+    log "installing huggingface_hub (pip)…"
+    python3 -m pip install --quiet --user huggingface_hub \
+      || die "failed to install huggingface_hub; install it and re-run."
+  fi
+  ./hack/fetch-model --classifier "$CLASSIFIER"
+else
+  log "model present in ${MODEL_DIR}."
+fi
+
+# --- Build ------------------------------------------------------------------
+log "building the playground binary (release, --features playground)…"
+cargo build --release --features playground --bin llm-d-sc-playground
+
+# --- Run --------------------------------------------------------------------
+export LLM_D_SC_MODEL_DIR="$MODEL_DIR"
+export LLM_D_SC_CLASSIFIER="$CLASSIFIER"
+export LLM_D_SC_CACHE="$CACHE_STRATEGY"
+export LLM_D_SC_REDIS_URL="$REDIS_URL"
+export LLM_D_SC_PLAYGROUND_ADDR="$UI_ADDR"
+
+# Open a browser once the binary is about to start (best-effort, non-fatal).
+if command -v xdg-open >/dev/null 2>&1; then
+  ( sleep 2; xdg-open "http://${UI_ADDR}" >/dev/null 2>&1 || true ) &
+elif command -v open >/dev/null 2>&1; then
+  ( sleep 2; open "http://${UI_ADDR}" >/dev/null 2>&1 || true ) &
+fi
+
+log "cache strategy: ${CACHE_STRATEGY}"
+log "starting… open http://${UI_ADDR}  (Ctrl-C to stop)"
+exec ./target/release/llm-d-sc-playground

--- a/hack/playground
+++ b/hack/playground
@@ -14,8 +14,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-CLASSIFIER="${LLM_D_SC_CLASSIFIER:-complexity}"
-MODEL_DIR="${LLM_D_SC_MODEL_DIR:-artifacts/models/${CLASSIFIER}}"
+# Classifiers offered in the UI dropdown. Default: all three built-ins.
+# Set LLM_D_SC_CLASSIFIER=<name> to demo a single classifier instead.
+CLASSIFIERS="${LLM_D_SC_CLASSIFIER:-complexity cost sensitivity}"
+MODELS_DIR="${LLM_D_SC_MODELS_DIR:-artifacts/models}"
 UI_ADDR="${LLM_D_SC_PLAYGROUND_ADDR:-127.0.0.1:8080}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 REDIS_URL="${LLM_D_SC_REDIS_URL:-redis://127.0.0.1:${REDIS_PORT}}"
@@ -81,27 +83,33 @@ else
   CACHE_STRATEGY="exact"
 fi
 
-# --- Model artifact ---------------------------------------------------------
-if [ ! -s "${MODEL_DIR}/model.safetensors" ]; then
-  log "model not found in ${MODEL_DIR}; fetching '${CLASSIFIER}' (~90MB, one-time)…"
-  command -v python3 >/dev/null 2>&1 || die "python3 not found; needed to download the model."
+# --- Model artifacts --------------------------------------------------------
+# Ensure the Python downloader is available once, then fetch each missing model.
+ensure_hf() {
+  command -v python3 >/dev/null 2>&1 || die "python3 not found; needed to download models."
   if ! python3 -c 'import huggingface_hub' >/dev/null 2>&1; then
     log "installing huggingface_hub (pip)…"
     python3 -m pip install --quiet --user huggingface_hub \
       || die "failed to install huggingface_hub; install it and re-run."
   fi
-  ./hack/fetch-model --classifier "$CLASSIFIER"
-else
-  log "model present in ${MODEL_DIR}."
-fi
+}
+for c in $CLASSIFIERS; do
+  if [ ! -s "${MODELS_DIR}/${c}/model.safetensors" ]; then
+    log "model '${c}' not found; fetching (~90MB, one-time)…"
+    ensure_hf
+    ./hack/fetch-model --classifier "$c"
+  else
+    log "model '${c}' present."
+  fi
+done
 
 # --- Build ------------------------------------------------------------------
 log "building the playground binary (release, --features playground)…"
 cargo build --release --features playground --bin llm-d-sc-playground
 
 # --- Run --------------------------------------------------------------------
-export LLM_D_SC_MODEL_DIR="$MODEL_DIR"
-export LLM_D_SC_CLASSIFIER="$CLASSIFIER"
+export LLM_D_SC_MODELS_DIR="$MODELS_DIR"
+export LLM_D_SC_PLAYGROUND_CLASSIFIERS="$(echo "$CLASSIFIERS" | tr ' ' ',')"
 export LLM_D_SC_CACHE="$CACHE_STRATEGY"
 export LLM_D_SC_REDIS_URL="$REDIS_URL"
 export LLM_D_SC_PLAYGROUND_ADDR="$UI_ADDR"

--- a/hack/redis-stack.sh
+++ b/hack/redis-stack.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Start a local Redis Stack (RediSearch) for the semantic-cache integration tests.
+set -euo pipefail
+exec docker run --rm -p 6379:6379 redis/redis-stack-server:latest

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -598,6 +598,9 @@ mod tests {
             total: std::time::Duration::ZERO,
             cache_hits: hits,
             cache_misses: misses,
+            l2_hits: 0,
+            l2_misses: 0,
+            l2_degraded: 0,
         }
     }
 

--- a/src/bin/bench-runner.rs
+++ b/src/bin/bench-runner.rs
@@ -262,6 +262,9 @@ fn stage_delta(before: MetricsSnapshot, after: MetricsSnapshot) -> MetricsSnapsh
         total: after.total.saturating_sub(before.total),
         cache_hits: after.cache_hits.saturating_sub(before.cache_hits),
         cache_misses: after.cache_misses.saturating_sub(before.cache_misses),
+        l2_hits: after.l2_hits.saturating_sub(before.l2_hits),
+        l2_misses: after.l2_misses.saturating_sub(before.l2_misses),
+        l2_degraded: after.l2_degraded.saturating_sub(before.l2_degraded),
     }
 }
 

--- a/src/bin/playground.html
+++ b/src/bin/playground.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>llm-d-sc · Semantic Cache Playground</title>
+<style>
+  :root {
+    --bg: #0b0f17;
+    --panel: #131a26;
+    --panel-2: #0f1520;
+    --border: #223049;
+    --text: #e6edf7;
+    --muted: #8ea0bd;
+    --accent: #6ea8fe;
+    --miss: #f5a524;
+    --l1: #4c8dff;
+    --l2: #2ecc71;
+    --degraded: #ff6b6b;
+    --shadow: 0 10px 30px rgba(0,0,0,.35);
+    --radius: 14px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background: radial-gradient(1200px 600px at 80% -10%, #1a2333 0%, var(--bg) 55%) fixed;
+    color: var(--text);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 20px 80px; }
+  header.hero { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 6px; }
+  .logo {
+    font-weight: 700; font-size: 22px; letter-spacing: .2px;
+    background: linear-gradient(90deg, var(--accent), var(--l2));
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .subtitle { color: var(--muted); font-size: 14px; }
+  .tagline { color: var(--muted); margin: 4px 0 26px; max-width: 720px; }
+  .grid { display: grid; grid-template-columns: 1fr 320px; gap: 20px; align-items: start; }
+  @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+  .card {
+    background: linear-gradient(180deg, var(--panel) 0%, var(--panel-2) 100%);
+    border: 1px solid var(--border); border-radius: var(--radius);
+    box-shadow: var(--shadow); padding: 18px;
+  }
+  .card + .card { margin-top: 20px; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .12em; color: var(--muted); margin: 0 0 12px; font-weight: 600; }
+  textarea {
+    width: 100%; min-height: 84px; resize: vertical; padding: 12px 14px;
+    background: #0a0e16; color: var(--text); border: 1px solid var(--border);
+    border-radius: 10px; font: inherit; outline: none;
+  }
+  textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(110,168,254,.15); }
+  .row { display: flex; gap: 10px; align-items: center; margin-top: 12px; flex-wrap: wrap; }
+  button.primary {
+    background: linear-gradient(90deg, var(--accent), #4c8dff);
+    color: #06101f; border: 0; padding: 11px 20px; border-radius: 10px;
+    font-weight: 700; cursor: pointer; font-size: 14px;
+  }
+  button.primary:disabled { opacity: .55; cursor: default; }
+  button.ghost {
+    background: #0d1420; color: var(--text); border: 1px solid var(--border);
+    padding: 8px 12px; border-radius: 999px; cursor: pointer; font-size: 13px;
+  }
+  button.ghost:hover { border-color: var(--accent); color: #fff; }
+  .examples { margin-top: 16px; }
+  .examples .lbl { color: var(--muted); font-size: 12px; margin-bottom: 8px; }
+  .chips { display: flex; gap: 8px; flex-wrap: wrap; }
+
+  .badge {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 12px; border-radius: 999px; font-weight: 700; font-size: 13px;
+    border: 1px solid transparent;
+  }
+  .badge .dot { width: 9px; height: 9px; border-radius: 50%; }
+  .b-miss { background: rgba(245,165,36,.12); color: var(--miss); border-color: rgba(245,165,36,.35); }
+  .b-miss .dot { background: var(--miss); }
+  .b-l1 { background: rgba(76,141,255,.12); color: var(--l1); border-color: rgba(76,141,255,.35); }
+  .b-l1 .dot { background: var(--l1); }
+  .b-l2 { background: rgba(46,204,113,.12); color: var(--l2); border-color: rgba(46,204,113,.35); }
+  .b-l2 .dot { background: var(--l2); }
+  .b-degraded { background: rgba(255,107,107,.12); color: var(--degraded); border-color: rgba(255,107,107,.35); }
+  .b-degraded .dot { background: var(--degraded); }
+
+  .result-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+  .latency { font-variant-numeric: tabular-nums; color: var(--text); font-weight: 700; }
+  .latency small { color: var(--muted); font-weight: 500; }
+  .provenance { color: var(--muted); font-size: 12px; margin: 10px 0 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+
+  .bars { margin-top: 14px; display: grid; gap: 8px; }
+  .bar-row { display: grid; grid-template-columns: 110px 1fr 64px; align-items: center; gap: 10px; }
+  .bar-row .name { font-weight: 600; font-size: 13px; }
+  .bar-row.top .name { color: var(--accent); }
+  .track { background: #0a0e16; border: 1px solid var(--border); border-radius: 8px; height: 16px; overflow: hidden; }
+  .fill { height: 100%; border-radius: 7px; background: linear-gradient(90deg, #35507f, var(--accent)); transition: width .4s ease; }
+  .bar-row.top .fill { background: linear-gradient(90deg, #1f7a46, var(--l2)); }
+  .score { text-align: right; font-variant-numeric: tabular-nums; color: var(--muted); font-size: 13px; }
+
+  .empty { color: var(--muted); padding: 28px 6px; text-align: center; }
+
+  .stats { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .stat { background: #0c131f; border: 1px solid var(--border); border-radius: 10px; padding: 12px; }
+  .stat .n { font-size: 22px; font-weight: 800; font-variant-numeric: tabular-nums; }
+  .stat .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; margin-top: 2px; }
+  .stat.l1 .n { color: var(--l1); } .stat.l2 .n { color: var(--l2); }
+  .stat.miss .n { color: var(--miss); } .stat.degraded .n { color: var(--degraded); }
+
+  .legend { color: var(--muted); font-size: 12px; margin-top: 14px; display: grid; gap: 6px; }
+  .legend .li { display: flex; gap: 8px; align-items: flex-start; }
+  .legend .dot { width: 9px; height: 9px; border-radius: 50%; margin-top: 5px; flex: 0 0 auto; }
+
+  .timeline { display: grid; gap: 8px; max-height: 360px; overflow: auto; }
+  .tl-item { display: grid; grid-template-columns: 1fr auto; gap: 6px 12px; align-items: center;
+    background: #0c131f; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
+  .tl-item .q { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tl-item .meta { display: flex; gap: 10px; align-items: center; }
+  .tl-item .toplabel { color: var(--muted); font-size: 12px; }
+  .tl-item .lat { font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; }
+  .tl-badge { font-size: 11px; padding: 3px 8px; border-radius: 999px; font-weight: 700; }
+
+  .err { color: var(--degraded); font-size: 13px; margin-top: 10px; }
+  .hint { color: var(--muted); font-size: 12px; margin-top: 8px; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="hero">
+    <span class="logo">llm-d-sc</span>
+    <span class="subtitle">Semantic Cache Playground</span>
+  </header>
+  <p class="tagline">
+    Classify a prompt, then send a <em>paraphrase</em>. On an exact-cache miss the prompt is embedded and a
+    semantically similar prior prompt reuses its stored label &mdash; an <strong>L2 semantic hit</strong> &mdash;
+    instead of re-ranking. Re-send the identical text for an <strong>L1 exact hit</strong>.
+  </p>
+
+  <div class="grid">
+    <div class="col-main">
+      <div class="card">
+        <h2>Prompt</h2>
+        <textarea id="prompt" placeholder="e.g. What is the capital of France?"></textarea>
+        <div class="row">
+          <button class="primary" id="go">Classify</button>
+          <span class="hint" id="statusline"></span>
+        </div>
+        <div class="examples">
+          <div class="lbl">Try these in order &mdash; watch #2 and #3 become L2 semantic hits:</div>
+          <div class="chips" id="chips"></div>
+        </div>
+        <div class="err" id="err"></div>
+      </div>
+
+      <div class="card" id="resultCard" style="display:none">
+        <div class="result-head">
+          <span class="badge" id="tierBadge"><span class="dot"></span><span id="tierText"></span></span>
+          <span class="latency"><span id="lat"></span><small> ms round-trip</small></span>
+        </div>
+        <div class="provenance" id="prov"></div>
+        <div class="bars" id="bars"></div>
+      </div>
+
+      <div class="card">
+        <h2>History</h2>
+        <div class="timeline" id="timeline"><div class="empty">No requests yet.</div></div>
+      </div>
+    </div>
+
+    <div class="col-side">
+      <div class="card">
+        <h2>Cache totals</h2>
+        <div class="stats">
+          <div class="stat l1"><div class="n" id="s-l1">0</div><div class="k">L1 exact hits</div></div>
+          <div class="stat l2"><div class="n" id="s-l2">0</div><div class="k">L2 semantic hits</div></div>
+          <div class="stat miss"><div class="n" id="s-miss">0</div><div class="k">Compute misses</div></div>
+          <div class="stat degraded"><div class="n" id="s-degraded">0</div><div class="k">Degraded</div></div>
+        </div>
+        <div class="legend">
+          <div class="li"><span class="dot" style="background:var(--miss)"></span><span><strong>Compute miss</strong> &mdash; no cached match; ran the model forward and stored the result.</span></div>
+          <div class="li"><span class="dot" style="background:var(--l1)"></span><span><strong>L1 exact hit</strong> &mdash; identical text served from the exact cache; no tokenizer, no forward.</span></div>
+          <div class="li"><span class="dot" style="background:var(--l2)"></span><span><strong>L2 semantic hit</strong> &mdash; a similar prior prompt's label was reused after embedding.</span></div>
+          <div class="li"><span class="dot" style="background:var(--degraded)"></span><span><strong>Degraded</strong> &mdash; Redis unreachable; failed open to the compute path.</span></div>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Backend</h2>
+        <div class="provenance" id="backend">loading&hellip;</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+const EXAMPLES = [
+  "What is the capital of France?",
+  "Which city is the capital of France?",
+  "What's France's capital city?",
+  "Prove by induction that the sum of the first n odd numbers is n squared.",
+];
+const TIER = {
+  COMPUTE_MISS: { cls: "b-miss", text: "COMPUTE MISS", short: "miss" },
+  L1_EXACT_HIT: { cls: "b-l1", text: "L1 EXACT HIT", short: "L1" },
+  L2_SEMANTIC_HIT: { cls: "b-l2", text: "L2 SEMANTIC HIT", short: "L2" },
+  DEGRADED: { cls: "b-degraded", text: "DEGRADED", short: "degr" },
+};
+const $ = (id) => document.getElementById(id);
+
+function renderChips() {
+  const box = $("chips");
+  EXAMPLES.forEach((ex, i) => {
+    const b = document.createElement("button");
+    b.className = "ghost";
+    b.textContent = (i + 1) + ". " + ex;
+    b.onclick = () => { $("prompt").value = ex; classify(); };
+    box.appendChild(b);
+  });
+}
+
+function badgeHTML(tier) {
+  const t = TIER[tier] || TIER.COMPUTE_MISS;
+  return { cls: t.cls, text: t.text, short: t.short };
+}
+
+function renderBars(ranked) {
+  const box = $("bars");
+  box.innerHTML = "";
+  if (!ranked || !ranked.length) return;
+  const scores = ranked.map(r => r.score);
+  const max = Math.max(...scores), min = Math.min(...scores);
+  const span = (max - min) || 1;
+  ranked.forEach((r, i) => {
+    const pct = Math.round(((r.score - min) / span) * 100);
+    const row = document.createElement("div");
+    row.className = "bar-row" + (i === 0 ? " top" : "");
+    row.innerHTML =
+      '<div class="name">' + r.label + '</div>' +
+      '<div class="track"><div class="fill" style="width:' + pct + '%"></div></div>' +
+      '<div class="score">' + r.score.toFixed(3) + '</div>';
+    box.appendChild(row);
+  });
+}
+
+function pushTimeline(text, data) {
+  const tl = $("timeline");
+  const empty = tl.querySelector(".empty");
+  if (empty) empty.remove();
+  const b = badgeHTML(data.tier);
+  const top = (data.ranked && data.ranked[0]) ? data.ranked[0].label : "—";
+  const item = document.createElement("div");
+  item.className = "tl-item";
+  const color = getComputedStyle(document.documentElement)
+    .getPropertyValue("--" + (b.cls.replace("b-", ""))) || "#888";
+  item.innerHTML =
+    '<div class="q" title="' + text.replace(/"/g, "&quot;") + '">' + text + '</div>' +
+    '<div class="meta">' +
+      '<span class="toplabel">' + top + '</span>' +
+      '<span class="lat">' + data.latency_ms + ' ms</span>' +
+      '<span class="tl-badge ' + b.cls + '">' + b.text + '</span>' +
+    '</div>';
+  tl.prepend(item);
+}
+
+function renderTotals(t) {
+  if (!t) return;
+  $("s-l1").textContent = t.cache_hits;
+  $("s-l2").textContent = t.l2_hits;
+  $("s-miss").textContent = t.l2_misses;
+  $("s-degraded").textContent = t.l2_degraded;
+}
+
+async function classify() {
+  const text = $("prompt").value.trim();
+  $("err").textContent = "";
+  if (!text) { $("err").textContent = "Enter a prompt first."; return; }
+  $("go").disabled = true;
+  $("statusline").textContent = "classifying…";
+  try {
+    const res = await fetch("/api/classify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) throw new Error("HTTP " + res.status + ": " + (await res.text()));
+    const data = await res.json();
+    if (data.error) throw new Error(data.error);
+
+    const b = badgeHTML(data.tier);
+    const badge = $("tierBadge");
+    badge.className = "badge " + b.cls;
+    $("tierText").textContent = b.text;
+    $("lat").textContent = data.latency_ms;
+    $("prov").textContent =
+      "classifier " + data.classifier_id + " · status " + data.status +
+      " · model " + short(data.model_revision) + " · taxonomy " + data.taxonomy_revision;
+    renderBars(data.ranked);
+    $("resultCard").style.display = "";
+    pushTimeline(text, data);
+    renderTotals(data.totals);
+    $("statusline").textContent = "";
+  } catch (e) {
+    $("err").textContent = String(e.message || e);
+    $("statusline").textContent = "";
+  } finally {
+    $("go").disabled = false;
+  }
+}
+
+function short(s) { return s && s.length > 12 ? s.slice(0, 12) + "…" : (s || "—"); }
+
+async function loadBackend() {
+  try {
+    const r = await fetch("/api/info");
+    const d = await r.json();
+    $("backend").textContent =
+      "classifier " + d.classifier_id + " · cache " + d.cache_strategy +
+      (d.redis_url ? " (" + d.redis_url + ")" : "") +
+      " · threshold " + d.threshold;
+    renderTotals(d.totals);
+  } catch (e) {
+    $("backend").textContent = "unavailable";
+  }
+}
+
+$("go").onclick = classify;
+$("prompt").addEventListener("keydown", (e) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") classify();
+});
+renderChips();
+loadBackend();
+</script>
+</body>
+</html>

--- a/src/bin/playground.html
+++ b/src/bin/playground.html
@@ -46,6 +46,15 @@
   }
   .card + .card { margin-top: 20px; }
   h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .12em; color: var(--muted); margin: 0 0 12px; font-weight: 600; }
+  .picker { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+  .picker label { color: var(--muted); font-size: 13px; }
+  select {
+    background: #0a0e16; color: var(--text); border: 1px solid var(--border);
+    border-radius: 10px; padding: 9px 12px; font: inherit; outline: none; cursor: pointer;
+    min-width: 180px;
+  }
+  select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(110,168,254,.15); }
+  .taxonomy { color: var(--muted); font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
   textarea {
     width: 100%; min-height: 84px; resize: vertical; padding: 12px 14px;
     background: #0a0e16; color: var(--text); border: 1px solid var(--border);
@@ -89,7 +98,7 @@
   .provenance { color: var(--muted); font-size: 12px; margin: 10px 0 4px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
 
   .bars { margin-top: 14px; display: grid; gap: 8px; }
-  .bar-row { display: grid; grid-template-columns: 110px 1fr 64px; align-items: center; gap: 10px; }
+  .bar-row { display: grid; grid-template-columns: 130px 1fr 64px; align-items: center; gap: 10px; }
   .bar-row .name { font-weight: 600; font-size: 13px; }
   .bar-row.top .name { color: var(--accent); }
   .track { background: #0a0e16; border: 1px solid var(--border); border-radius: 8px; height: 16px; overflow: hidden; }
@@ -105,6 +114,7 @@
   .stat .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; margin-top: 2px; }
   .stat.l1 .n { color: var(--l1); } .stat.l2 .n { color: var(--l2); }
   .stat.miss .n { color: var(--miss); } .stat.degraded .n { color: var(--degraded); }
+  .stats-note { color: var(--muted); font-size: 11px; margin: 10px 0 0; }
 
   .legend { color: var(--muted); font-size: 12px; margin-top: 14px; display: grid; gap: 6px; }
   .legend .li { display: flex; gap: 8px; align-items: flex-start; }
@@ -115,6 +125,7 @@
     background: #0c131f; border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
   .tl-item .q { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .tl-item .meta { display: flex; gap: 10px; align-items: center; }
+  .tl-item .clf { color: var(--accent); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; }
   .tl-item .toplabel { color: var(--muted); font-size: 12px; }
   .tl-item .lat { font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; }
   .tl-badge { font-size: 11px; padding: 3px 8px; border-radius: 999px; font-weight: 700; }
@@ -131,14 +142,20 @@
     <span class="subtitle">Semantic Cache Playground</span>
   </header>
   <p class="tagline">
-    Classify a prompt, then send a <em>paraphrase</em>. On an exact-cache miss the prompt is embedded and a
-    semantically similar prior prompt reuses its stored label &mdash; an <strong>L2 semantic hit</strong> &mdash;
-    instead of re-ranking. Re-send the identical text for an <strong>L1 exact hit</strong>.
+    Pick a classifier, classify a prompt, then send a <em>paraphrase</em>. On an exact-cache miss the prompt is
+    embedded and a semantically similar prior prompt reuses its stored label &mdash; an <strong>L2 semantic hit</strong>
+    &mdash; instead of re-ranking. Re-send the identical text for an <strong>L1 exact hit</strong>. Each classifier
+    keeps its own isolated cache.
   </p>
 
   <div class="grid">
     <div class="col-main">
       <div class="card">
+        <div class="picker">
+          <label for="classifier">Classifier</label>
+          <select id="classifier"></select>
+          <span class="taxonomy" id="taxonomy"></span>
+        </div>
         <h2>Prompt</h2>
         <textarea id="prompt" placeholder="e.g. What is the capital of France?"></textarea>
         <div class="row">
@@ -176,6 +193,7 @@
           <div class="stat miss"><div class="n" id="s-miss">0</div><div class="k">Compute misses</div></div>
           <div class="stat degraded"><div class="n" id="s-degraded">0</div><div class="k">Degraded</div></div>
         </div>
+        <p class="stats-note" id="statsNote">Totals for the selected classifier.</p>
         <div class="legend">
           <div class="li"><span class="dot" style="background:var(--miss)"></span><span><strong>Compute miss</strong> &mdash; no cached match; ran the model forward and stored the result.</span></div>
           <div class="li"><span class="dot" style="background:var(--l1)"></span><span><strong>L1 exact hit</strong> &mdash; identical text served from the exact cache; no tokenizer, no forward.</span></div>
@@ -192,11 +210,32 @@
 </div>
 
 <script>
-const EXAMPLES = [
+// Per-classifier example sets. Each set: three close paraphrases (a miss then
+// two L2 semantic hits) plus a distinct fourth prompt (a fresh compute miss).
+const EXAMPLES = {
+  complexity: [
+    "What is the capital of France?",
+    "Which city is the capital of France?",
+    "What's France's capital city?",
+    "Prove by induction that the sum of the first n odd numbers is n squared.",
+  ],
+  cost: [
+    "Write a short poem about the sea.",
+    "Write a brief poem about the sea.",
+    "Compose a short poem about the sea.",
+    "Translate this entire 400-page novel into French, preserving tone and style.",
+  ],
+  sensitivity: [
+    "What is the weather forecast for tomorrow?",
+    "What's tomorrow's weather forecast?",
+    "Tell me the weather forecast for tomorrow.",
+    "Store my social security number 123-45-6789 for later use.",
+  ],
+};
+const FALLBACK_EXAMPLES = [
   "What is the capital of France?",
   "Which city is the capital of France?",
   "What's France's capital city?",
-  "Prove by induction that the sum of the first n odd numbers is n squared.",
 ];
 const TIER = {
   COMPUTE_MISS: { cls: "b-miss", text: "COMPUTE MISS", short: "miss" },
@@ -206,9 +245,16 @@ const TIER = {
 };
 const $ = (id) => document.getElementById(id);
 
+let CLASSIFIERS = [];   // [{name, classifier_id, labels, totals}]
+let current = null;     // selected classifier name
+
+function currentEntry() { return CLASSIFIERS.find((c) => c.name === current); }
+
 function renderChips() {
   const box = $("chips");
-  EXAMPLES.forEach((ex, i) => {
+  box.innerHTML = "";
+  const set = EXAMPLES[current] || FALLBACK_EXAMPLES;
+  set.forEach((ex, i) => {
     const b = document.createElement("button");
     b.className = "ghost";
     b.textContent = (i + 1) + ". " + ex;
@@ -226,7 +272,7 @@ function renderBars(ranked) {
   const box = $("bars");
   box.innerHTML = "";
   if (!ranked || !ranked.length) return;
-  const scores = ranked.map(r => r.score);
+  const scores = ranked.map((r) => r.score);
   const max = Math.max(...scores), min = Math.min(...scores);
   const span = (max - min) || 1;
   ranked.forEach((r, i) => {
@@ -241,7 +287,7 @@ function renderBars(ranked) {
   });
 }
 
-function pushTimeline(text, data) {
+function pushTimeline(text, clf, data) {
   const tl = $("timeline");
   const empty = tl.querySelector(".empty");
   if (empty) empty.remove();
@@ -249,11 +295,10 @@ function pushTimeline(text, data) {
   const top = (data.ranked && data.ranked[0]) ? data.ranked[0].label : "—";
   const item = document.createElement("div");
   item.className = "tl-item";
-  const color = getComputedStyle(document.documentElement)
-    .getPropertyValue("--" + (b.cls.replace("b-", ""))) || "#888";
   item.innerHTML =
     '<div class="q" title="' + text.replace(/"/g, "&quot;") + '">' + text + '</div>' +
     '<div class="meta">' +
+      '<span class="clf">' + clf + '</span>' +
       '<span class="toplabel">' + top + '</span>' +
       '<span class="lat">' + data.latency_ms + ' ms</span>' +
       '<span class="tl-badge ' + b.cls + '">' + b.text + '</span>' +
@@ -262,24 +307,36 @@ function pushTimeline(text, data) {
 }
 
 function renderTotals(t) {
-  if (!t) return;
+  t = t || { cache_hits: 0, l2_hits: 0, l2_misses: 0, l2_degraded: 0 };
   $("s-l1").textContent = t.cache_hits;
   $("s-l2").textContent = t.l2_hits;
   $("s-miss").textContent = t.l2_misses;
   $("s-degraded").textContent = t.l2_degraded;
 }
 
+function onClassifierChange() {
+  current = $("classifier").value;
+  const e = currentEntry();
+  $("taxonomy").textContent = e && e.labels && e.labels.length
+    ? "labels: " + e.labels.join(" · ") : "";
+  $("statsNote").textContent = "Totals for '" + current + "'.";
+  renderChips();
+  renderTotals(e ? e.totals : null);
+}
+
 async function classify() {
   const text = $("prompt").value.trim();
+  const clf = current;
   $("err").textContent = "";
   if (!text) { $("err").textContent = "Enter a prompt first."; return; }
+  if (!clf) { $("err").textContent = "No classifier available."; return; }
   $("go").disabled = true;
   $("statusline").textContent = "classifying…";
   try {
     const res = await fetch("/api/classify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({ text, classifier: clf }),
     });
     if (!res.ok) throw new Error("HTTP " + res.status + ": " + (await res.text()));
     const data = await res.json();
@@ -295,8 +352,12 @@ async function classify() {
       " · model " + short(data.model_revision) + " · taxonomy " + data.taxonomy_revision;
     renderBars(data.ranked);
     $("resultCard").style.display = "";
-    pushTimeline(text, data);
-    renderTotals(data.totals);
+    pushTimeline(text, clf, data);
+
+    // Keep this classifier's cached totals fresh, and show them if it's still selected.
+    const e = CLASSIFIERS.find((c) => c.name === clf);
+    if (e) e.totals = data.totals;
+    if (clf === current) renderTotals(data.totals);
     $("statusline").textContent = "";
   } catch (e) {
     $("err").textContent = String(e.message || e);
@@ -312,21 +373,32 @@ async function loadBackend() {
   try {
     const r = await fetch("/api/info");
     const d = await r.json();
+    CLASSIFIERS = d.classifiers || [];
+    const sel = $("classifier");
+    sel.innerHTML = "";
+    CLASSIFIERS.forEach((c) => {
+      const o = document.createElement("option");
+      o.value = c.name;
+      o.textContent = c.name;
+      sel.appendChild(o);
+    });
+    current = CLASSIFIERS.length ? CLASSIFIERS[0].name : null;
+    if (current) sel.value = current;
     $("backend").textContent =
-      "classifier " + d.classifier_id + " · cache " + d.cache_strategy +
+      CLASSIFIERS.length + " classifier(s) · cache " + d.cache_strategy +
       (d.redis_url ? " (" + d.redis_url + ")" : "") +
       " · threshold " + d.threshold;
-    renderTotals(d.totals);
+    onClassifierChange();
   } catch (e) {
     $("backend").textContent = "unavailable";
   }
 }
 
 $("go").onclick = classify;
+$("classifier").addEventListener("change", onClassifierChange);
 $("prompt").addEventListener("keydown", (e) => {
   if ((e.metaKey || e.ctrlKey) && e.key === "Enter") classify();
 });
-renderChips();
 loadBackend();
 </script>
 </body>

--- a/src/bin/playground.rs
+++ b/src/bin/playground.rs
@@ -21,15 +21,27 @@
 //! exactly one classify call.
 //!
 //! Served surface (plain HTTP over `tiny_http`, same-origin, no framework):
-//!   GET  /              -> the single-page UI (embedded at build time)
-//!   GET  /api/info      -> available classifiers (id + taxonomy + totals) + cache
-//!   POST /api/classify  -> { "text": "...", "classifier": "..." }
-//!                          -> ranked labels + cache tier + latency
+//!   GET  /                    -> the single-page UI (embedded at build time)
+//!   GET  /api/info            -> available classifiers (id + taxonomy + totals) + cache
+//!   POST /api/classify        -> { "text": "...", "classifier": "..." }
+//!                                -> ranked labels + cache tier + latency
+//!   POST /v1/chat/completions -> OpenAI-compatible chat completion, served
+//!                                through the semantic RESPONSE cache: a
+//!                                near-duplicate prompt to the same model is
+//!                                answered from Redis (header `x-praxis-cache:
+//!                                hit`); a miss is forwarded to the upstream vLLM
+//!                                (`LLM_D_SC_VLLM_URL`), returned, and cached
+//!                                (`miss`). `stream:true` bypasses the cache
+//!                                (`bypass`). Only active when both
+//!                                `LLM_D_SC_VLLM_URL` and a Redis semantic cache
+//!                                are configured.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
+use llm_d_sc::cache::response::RedisResponseCache;
 use llm_d_sc::classify::{CandleClassifier, ClassifierRuntime};
 use llm_d_sc::config::CacheConfig;
+use llm_d_sc::embedding::Embedder;
 use llm_d_sc::grpc::classify::{ClassifyClient, ClassifyRequest, ClassifyServer};
 use llm_d_sc::metrics::MetricsSnapshot;
 use llm_d_sc::taxonomy::ClassifierDefinition;
@@ -57,6 +69,18 @@ struct Classifier {
     server: ClassifyServer,
     client: ClassifyClient,
     baseline: MetricsSnapshot,
+}
+
+/// State for the semantic RESPONSE-cache route (`/v1/chat/completions`): an
+/// embedder to key completions by prompt similarity, the Redis-backed response
+/// cache, and the upstream vLLM to forward misses to. Present only when both an
+/// upstream and a Redis cache are configured.
+struct ResponseCacheCtx {
+    embedder: Embedder,
+    cache: RedisResponseCache,
+    vllm_url: String,
+    threshold: f32,
+    upstream_timeout: Duration,
 }
 
 fn main() -> std::io::Result<()> {
@@ -109,6 +133,21 @@ fn main() -> std::io::Result<()> {
         timeout_ms: 50,
     });
 
+    // Optional semantic RESPONSE cache in front of an upstream vLLM. Active only
+    // when both LLM_D_SC_VLLM_URL and a Redis backend are configured; otherwise
+    // the /v1/chat/completions route is disabled (404). Keys completions by
+    // prompt similarity using its own embedder (the primary classifier's model).
+    let response_cache = build_response_cache(&models_dir, &cache_cfg);
+    match &response_cache {
+        Some(ctx) => eprintln!(
+            "llm-d-sc playground: response cache ENABLED -> upstream {} (threshold {:.2})",
+            ctx.vllm_url, ctx.threshold
+        ),
+        None => eprintln!(
+            "llm-d-sc playground: response cache disabled (set LLM_D_SC_VLLM_URL + a redis-semantic cache to enable)"
+        ),
+    }
+
     let http = tiny_http::Server::http(&ui_addr).map_err(|e| {
         std::io::Error::other(format!("could not bind playground UI on {ui_addr}: {e}"))
     })?;
@@ -130,6 +169,9 @@ fn main() -> std::io::Result<()> {
         let method = request.method().clone();
         let url = request.url().to_string();
 
+        // Extra response headers set by a route (e.g. the response-cache tier).
+        let mut extra_headers: Vec<tiny_http::Header> = Vec::new();
+
         let (status, content_type, body): (u16, &str, String) = match (method, url.as_str()) {
             (tiny_http::Method::Get, "/") => {
                 (200, "text/html; charset=utf-8", INDEX_HTML.to_string())
@@ -145,14 +187,33 @@ fn main() -> std::io::Result<()> {
                     Err(msg) => (200, "application/json", error_json(&msg)),
                 }
             }
+            (tiny_http::Method::Post, "/v1/chat/completions") => {
+                let mut raw = String::new();
+                let _ = request.as_reader().read_to_string(&mut raw);
+                match handle_chat(response_cache.as_ref(), &raw) {
+                    Ok((code, cache_status, json)) => {
+                        if let Ok(h) = tiny_http::Header::from_bytes(
+                            &b"x-praxis-cache"[..],
+                            cache_status.as_bytes(),
+                        ) {
+                            extra_headers.push(h);
+                        }
+                        (code, "application/json", json)
+                    }
+                    Err(msg) => (502, "application/json", error_json(&msg)),
+                }
+            }
             _ => (404, "text/plain", "not found".to_string()),
         };
 
         let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], content_type.as_bytes())
             .expect("static content-type header is valid");
-        let response = tiny_http::Response::from_string(body)
+        let mut response = tiny_http::Response::from_string(body)
             .with_status_code(status)
             .with_header(header);
+        for h in extra_headers {
+            response = response.with_header(h);
+        }
         let _ = request.respond(response);
     }
 
@@ -375,4 +436,184 @@ fn info_json(classifiers: &[Classifier], cfg: &CacheConfig) -> String {
 
 fn error_json(message: &str) -> String {
     serde_json::json!({ "error": message }).to_string()
+}
+
+/// Build the response-cache context if both an upstream vLLM URL and a Redis
+/// semantic backend are configured. Any load/connect failure logs and disables
+/// the route (returns `None`) rather than aborting the playground.
+fn build_response_cache(models_dir: &str, cache_cfg: &CacheConfig) -> Option<ResponseCacheCtx> {
+    let vllm_url = std::env::var("LLM_D_SC_VLLM_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    let redis_url = cache_cfg.redis_url.clone()?;
+
+    let threshold = std::env::var("LLM_D_SC_RESP_CACHE_THRESHOLD")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(0.92);
+    let ttl_secs = std::env::var("LLM_D_SC_RESP_CACHE_TTL")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(cache_cfg.ttl_secs);
+    // The classification cache's timeout (LLM_D_SC_TIMEOUT_MS, default 50ms) is
+    // too tight for a vector-KNN FT.SEARCH: the first (cold) search or a fresh
+    // pooled connection can exceed it, and a timed-out lookup fails open to a
+    // false miss. Use a dedicated, more generous bound (warm lookups are still
+    // single-digit ms; this only caps the cold/slow path).
+    let timeout_ms = std::env::var("LLM_D_SC_RESP_CACHE_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(1000);
+
+    // The response cache keys completions by SEMANTIC similarity, so it needs a
+    // general sentence-embedding model — NOT a task-tuned classifier model.
+    // Classifier embeddings are anisotropic: unrelated prompts score ~0.97 and a
+    // true paraphrase can score *lower* than an unrelated one, so an absolute
+    // cosine threshold is meaningless there. Default to the baked all-MiniLM-L6-v2
+    // baseline (clean separation: paraphrase ~0.99, unrelated ~0.75); override
+    // with LLM_D_SC_RESP_EMBED_DIR.
+    let embed_dir = std::env::var("LLM_D_SC_RESP_EMBED_DIR")
+        .unwrap_or_else(|_| format!("{models_dir}/baseline-minilm"));
+    let embedder = Embedder::load(
+        format!("{embed_dir}/config.json"),
+        format!("{embed_dir}/model.safetensors"),
+        format!("{embed_dir}/tokenizer.json"),
+        format!("{embed_dir}/1_Pooling/config.json"),
+    )
+    .map_err(|e| {
+        eprintln!(
+            "llm-d-sc playground: response cache disabled — embedder load failed at {embed_dir}: {e:?}"
+        )
+    })
+    .ok()?;
+
+    let cache = RedisResponseCache::connect(&redis_url, threshold, ttl_secs, timeout_ms)
+        .map_err(|e| {
+            eprintln!("llm-d-sc playground: response cache disabled — redis connect failed: {e}")
+        })
+        .ok()?;
+
+    Some(ResponseCacheCtx {
+        embedder,
+        cache,
+        vllm_url,
+        threshold,
+        upstream_timeout: Duration::from_secs(120),
+    })
+}
+
+/// Serve one chat-completion request through the semantic response cache.
+///
+/// Returns `(http_status, cache_status, body_json)` where `cache_status` is
+/// "hit" (served from Redis), "miss" (forwarded upstream then cached), or
+/// "bypass" (streaming or non-embeddable prompt: forwarded, not cached).
+fn handle_chat(
+    ctx: Option<&ResponseCacheCtx>,
+    raw: &str,
+) -> Result<(u16, &'static str, String), String> {
+    let ctx = ctx.ok_or("response cache route is disabled (LLM_D_SC_VLLM_URL not set)")?;
+    let req: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| "request body must be JSON".to_string())?;
+
+    let stream = req.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let model = req
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // Cache only non-streaming requests whose last user message is a plain
+    // string we can embed. Everything else is forwarded transparently.
+    if !stream {
+        if let Some(text) = last_user_message(&req) {
+            if let Ok(vector) = ctx.embedder.embed(&text) {
+                if let Some(hit) = ctx.cache.lookup(&vector, &model) {
+                    return Ok((200, "hit", hit));
+                }
+                let (code, body) = forward_upstream(&ctx.vllm_url, raw, ctx.upstream_timeout)?;
+                if code == 200 {
+                    ctx.cache.insert(&vector, &model, &body);
+                }
+                return Ok((code, "miss", body));
+            }
+        }
+    }
+
+    let (code, body) = forward_upstream(&ctx.vllm_url, raw, ctx.upstream_timeout)?;
+    Ok((code, "bypass", body))
+}
+
+/// Forward a chat-completion request body to the upstream vLLM and return
+/// `(status, body)`. HTTP error statuses (4xx/5xx) are returned as-is so the
+/// caller sees the real upstream error; only transport failures are `Err`.
+fn forward_upstream(base: &str, body: &str, timeout: Duration) -> Result<(u16, String), String> {
+    let url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
+    match ureq::post(&url)
+        .timeout(timeout)
+        .set("Content-Type", "application/json")
+        .send_string(body)
+    {
+        Ok(r) => {
+            let code = r.status();
+            let text = r
+                .into_string()
+                .map_err(|e| format!("reading upstream body: {e}"))?;
+            Ok((code, text))
+        }
+        Err(ureq::Error::Status(code, r)) => Ok((code, r.into_string().unwrap_or_default())),
+        Err(e) => Err(format!("upstream request failed: {e}")),
+    }
+}
+
+/// The most recent `role:"user"` message's string content, if present. Array /
+/// multimodal content is not embeddable here and yields `None` (bypass).
+fn last_user_message(req: &serde_json::Value) -> Option<String> {
+    req.get("messages")?
+        .as_array()?
+        .iter()
+        .rev()
+        .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn last_user_message_picks_the_final_user_turn() {
+        let req = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "second"}
+            ]
+        });
+        assert_eq!(last_user_message(&req).as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn last_user_message_is_none_without_user_turn() {
+        let req = serde_json::json!({"messages": [{"role": "system", "content": "x"}]});
+        assert!(last_user_message(&req).is_none());
+    }
+
+    #[test]
+    fn last_user_message_is_none_for_array_content() {
+        // Multimodal content is an array, not a string, and is not embeddable.
+        let req = serde_json::json!({
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        });
+        assert!(last_user_message(&req).is_none());
+    }
+
+    #[test]
+    fn handle_chat_errors_when_disabled() {
+        let out = handle_chat(None, "{}");
+        assert!(out.is_err());
+    }
 }

--- a/src/bin/playground.rs
+++ b/src/bin/playground.rs
@@ -1,0 +1,272 @@
+//! Interactive demo playground for the semantic cache (feature `playground`).
+//!
+//! This binary is NOT part of the served product — it exists to demo and poke at
+//! the L1 exact / L2 semantic cache tiers from a browser. It hosts the REAL
+//! production path in-process: it loads and warms the resident Candle classifier,
+//! binds the same [`ClassifyServer`] the service binary uses (so the environment
+//! selects the `redis-semantic` L2 tier exactly as in production), and drives it
+//! through the blocking [`ClassifyClient`].
+//!
+//! Why in-process: the gRPC response carries only ranked labels + revisions, and
+//! there is no metrics HTTP endpoint. The ONLY way to tell whether a request was
+//! an L1 exact hit, an L2 semantic hit, or a compute miss is to read the
+//! in-process [`MetricsSnapshot`] counter deltas around each call. So the UI
+//! backend must host the server to observe those counters. Requests are handled
+//! one at a time (single-threaded loop), which keeps each delta attributable to
+//! exactly one classify call.
+//!
+//! Served surface (plain HTTP over `tiny_http`, same-origin, no framework):
+//!   GET  /              -> the single-page UI (embedded at build time)
+//!   GET  /api/info      -> classifier id + cache strategy + running totals
+//!   POST /api/classify  -> { "text": "..." } -> ranked labels + cache tier + latency
+
+use std::time::Instant;
+
+use llm_d_sc::classify::{load_and_warm_modelcar, ClassifierRuntime};
+use llm_d_sc::config::CacheConfig;
+use llm_d_sc::grpc::classify::{ClassifyClient, ClassifyRequest, ClassifyServer};
+use llm_d_sc::metrics::MetricsSnapshot;
+
+/// The single-page UI, embedded so the binary is self-contained.
+const INDEX_HTML: &str = include_str!("playground.html");
+
+/// Default per-classifier model directory (matches the CLI convention).
+const DEFAULT_MODEL_DIR: &str = "artifacts/models/complexity";
+/// Default address the browser UI is served on.
+const DEFAULT_UI_ADDR: &str = "127.0.0.1:8080";
+
+fn main() -> std::io::Result<()> {
+    let model_dir =
+        std::env::var("LLM_D_SC_MODEL_DIR").unwrap_or_else(|_| DEFAULT_MODEL_DIR.to_string());
+    let ui_addr =
+        std::env::var("LLM_D_SC_PLAYGROUND_ADDR").unwrap_or_else(|_| DEFAULT_UI_ADDR.to_string());
+
+    // Load + warm the resident Candle classifier. ANY failure here (missing
+    // ModelCar dir, bad layout, warmup forward failed) aborts with an
+    // actionable error — a directory that merely exists must not serve.
+    eprintln!("llm-d-sc playground: loading model from {model_dir} …");
+    let classifier = load_and_warm_modelcar(&model_dir).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("could not load/warm model at {model_dir}: {e}\n\nRun ./hack/fetch-model --classifier complexity (or point LLM_D_SC_MODEL_DIR at a ModelCar dir)."),
+        )
+    })?;
+    let meta = classifier.metadata();
+    let classifier_id = meta.classifier_id.clone();
+
+    // Bind the production server in-process. `bind_with_classifier` reads the
+    // cache strategy from the environment (LLM_D_SC_CACHE=redis-semantic +
+    // LLM_D_SC_REDIS_URL), and fails open to the exact cache if Redis is
+    // unreachable or the feature is off — the UI keeps working either way.
+    let server = ClassifyServer::bind_with_classifier("127.0.0.1:0", classifier)?;
+    let grpc_addr = server.local_addr();
+    let mut client = ClassifyClient::connect(&grpc_addr)?;
+
+    // Snapshot of the cache config purely for display in the UI header.
+    let cache_cfg = CacheConfig::from_env().unwrap_or_else(|_| CacheConfig {
+        strategy: "exact".into(),
+        redis_url: None,
+        threshold: 0.90,
+        ttl_secs: 86_400,
+        timeout_ms: 50,
+    });
+
+    // Prime the semantic tier: RediSearch creates its vector index lazily on the
+    // first insert, so the very first lookup hits a not-yet-existent index and
+    // reads as DEGRADED (fail-open). A throwaway warmup classify creates the
+    // index before any user request, and the post-warmup snapshot below becomes
+    // the baseline the UI totals are reported against — so warmup activity stays
+    // invisible and user-facing totals start at zero.
+    let _ = client.classify(ClassifyRequest {
+        request_id: "pg-warmup".to_string(),
+        session_id: "playground".to_string(),
+        context: "llm-d-sc playground warmup probe".to_string(),
+        signals: Vec::new(),
+    });
+    let baseline = server.metrics_snapshot();
+
+    let http = tiny_http::Server::http(&ui_addr).map_err(|e| {
+        std::io::Error::other(format!("could not bind playground UI on {ui_addr}: {e}"))
+    })?;
+
+    eprintln!(
+        "llm-d-sc playground: classifier '{classifier_id}', cache strategy '{}', gRPC {grpc_addr}",
+        cache_cfg.strategy
+    );
+    eprintln!();
+    eprintln!("    ▶  Playground UI ready:  http://{ui_addr}");
+    eprintln!();
+
+    let mut request_seq: u64 = 0;
+
+    // Single-threaded request loop: handling one request at a time makes each
+    // metrics delta attributable to exactly one classify call.
+    for mut request in http.incoming_requests() {
+        let method = request.method().clone();
+        let url = request.url().to_string();
+
+        let (status, content_type, body): (u16, &str, String) = match (method, url.as_str()) {
+            (tiny_http::Method::Get, "/") => {
+                (200, "text/html; charset=utf-8", INDEX_HTML.to_string())
+            }
+            (tiny_http::Method::Get, "/api/info") => (
+                200,
+                "application/json",
+                info_json(
+                    &classifier_id,
+                    &cache_cfg,
+                    &server.metrics_snapshot(),
+                    &baseline,
+                ),
+            ),
+            (tiny_http::Method::Post, "/api/classify") => {
+                let mut raw = String::new();
+                let _ = request.as_reader().read_to_string(&mut raw);
+                match handle_classify(&mut client, &server, &raw, &mut request_seq, &baseline) {
+                    Ok(json) => (200, "application/json", json),
+                    Err(msg) => (200, "application/json", error_json(&msg)),
+                }
+            }
+            _ => (404, "text/plain", "not found".to_string()),
+        };
+
+        let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], content_type.as_bytes())
+            .expect("static content-type header is valid");
+        let response = tiny_http::Response::from_string(body)
+            .with_status_code(status)
+            .with_header(header);
+        let _ = request.respond(response);
+    }
+
+    Ok(())
+}
+
+/// Run one classify call and describe the outcome, including which cache tier
+/// served it (derived from the metrics counter delta around the call).
+fn handle_classify(
+    client: &mut ClassifyClient,
+    server: &ClassifyServer,
+    raw_body: &str,
+    seq: &mut u64,
+    baseline: &MetricsSnapshot,
+) -> Result<String, String> {
+    let text =
+        parse_text(raw_body).ok_or_else(|| "request body must be {\"text\": \"…\"}".to_string())?;
+    if text.trim().is_empty() {
+        return Err("prompt text is empty".to_string());
+    }
+
+    *seq += 1;
+    let request = ClassifyRequest {
+        request_id: format!("pg-{seq}"),
+        session_id: "playground".to_string(),
+        context: text,
+        // Empty = no signal constraint, so this works against any served taxonomy.
+        signals: Vec::new(),
+    };
+
+    let before = server.metrics_snapshot();
+    let started = Instant::now();
+    let response = client
+        .classify(request)
+        .map_err(|s| format!("classify failed: {} ({})", s.message(), s.code()))?;
+    let latency_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let after = server.metrics_snapshot();
+
+    let tier = classify_tier(&before, &after);
+    Ok(response_json(&response, tier, latency_ms, &after, baseline))
+}
+
+/// Partition a served request into a cache tier from the counter delta.
+///
+/// | tier            | Δcache_hits | Δl2_hits | Δl2_degraded |
+/// |-----------------|-------------|----------|--------------|
+/// | L1_EXACT_HIT    | +1          | 0        | 0            |
+/// | L2_SEMANTIC_HIT | 0           | +1       | 0            |
+/// | DEGRADED        | 0           | 0        | +1           |
+/// | COMPUTE_MISS    | 0           | 0        | 0            |
+fn classify_tier(before: &MetricsSnapshot, after: &MetricsSnapshot) -> &'static str {
+    if after.cache_hits > before.cache_hits {
+        "L1_EXACT_HIT"
+    } else if after.l2_hits > before.l2_hits {
+        "L2_SEMANTIC_HIT"
+    } else if after.l2_degraded > before.l2_degraded {
+        "DEGRADED"
+    } else {
+        "COMPUTE_MISS"
+    }
+}
+
+/// Extract the `text` field from a `{"text": "..."}` JSON body.
+fn parse_text(raw: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    v.get("text")?.as_str().map(|s| s.to_string())
+}
+
+/// Human-readable name for a proto `ClassificationStatus` discriminant.
+fn status_name(status: i32) -> &'static str {
+    match status {
+        1 => "OK",
+        2 => "ABSTAIN",
+        3 => "UNAVAILABLE",
+        _ => "UNSPECIFIED",
+    }
+}
+
+/// Running totals since serving began, i.e. the live snapshot minus the
+/// post-warmup baseline (so index-priming activity is not shown to the user).
+fn totals_json(snap: &MetricsSnapshot, baseline: &MetricsSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "cache_hits": snap.cache_hits.saturating_sub(baseline.cache_hits),
+        "cache_misses": snap.cache_misses.saturating_sub(baseline.cache_misses),
+        "l2_hits": snap.l2_hits.saturating_sub(baseline.l2_hits),
+        "l2_misses": snap.l2_misses.saturating_sub(baseline.l2_misses),
+        "l2_degraded": snap.l2_degraded.saturating_sub(baseline.l2_degraded),
+    })
+}
+
+fn response_json(
+    response: &llm_d_sc::grpc::classify::ClassifyResponse,
+    tier: &str,
+    latency_ms: f64,
+    totals: &MetricsSnapshot,
+    baseline: &MetricsSnapshot,
+) -> String {
+    let ranked: Vec<serde_json::Value> = response
+        .ranked
+        .iter()
+        .map(|r| serde_json::json!({ "label": r.label, "score": r.score }))
+        .collect();
+    serde_json::json!({
+        "tier": tier,
+        "latency_ms": format!("{latency_ms:.1}"),
+        "status": status_name(response.status),
+        "classifier_id": response.classifier_id,
+        "model_revision": response.model_revision,
+        "tokenizer_revision": response.tokenizer_revision,
+        "taxonomy_revision": response.taxonomy_revision,
+        "ranked": ranked,
+        "totals": totals_json(totals, baseline),
+    })
+    .to_string()
+}
+
+fn info_json(
+    classifier_id: &str,
+    cfg: &CacheConfig,
+    totals: &MetricsSnapshot,
+    baseline: &MetricsSnapshot,
+) -> String {
+    serde_json::json!({
+        "classifier_id": classifier_id,
+        "cache_strategy": cfg.strategy,
+        "redis_url": cfg.redis_url,
+        "threshold": cfg.threshold,
+        "totals": totals_json(totals, baseline),
+    })
+    .to_string()
+}
+
+fn error_json(message: &str) -> String {
+    serde_json::json!({ "error": message }).to_string()
+}

--- a/src/bin/playground.rs
+++ b/src/bin/playground.rs
@@ -2,10 +2,15 @@
 //!
 //! This binary is NOT part of the served product — it exists to demo and poke at
 //! the L1 exact / L2 semantic cache tiers from a browser. It hosts the REAL
-//! production path in-process: it loads and warms the resident Candle classifier,
-//! binds the same [`ClassifyServer`] the service binary uses (so the environment
-//! selects the `redis-semantic` L2 tier exactly as in production), and drives it
-//! through the blocking [`ClassifyClient`].
+//! production path in-process: it loads and warms one resident Candle classifier
+//! per available taxonomy, binds the same [`ClassifyServer`] the service binary
+//! uses for each (so the environment selects the `redis-semantic` L2 tier exactly
+//! as in production), and drives them through the blocking [`ClassifyClient`].
+//!
+//! Multiple classifiers, one Redis: the two-tier cache namespaces every entry by
+//! an identity tag that begins with the classifier id, so complexity, cost and
+//! sensitivity share one Redis instance without ever reading each other's cached
+//! labels. The UI picks which classifier a prompt is sent to.
 //!
 //! Why in-process: the gRPC response carries only ranked labels + revisions, and
 //! there is no metrics HTTP endpoint. The ONLY way to tell whether a request was
@@ -17,52 +22,85 @@
 //!
 //! Served surface (plain HTTP over `tiny_http`, same-origin, no framework):
 //!   GET  /              -> the single-page UI (embedded at build time)
-//!   GET  /api/info      -> classifier id + cache strategy + running totals
-//!   POST /api/classify  -> { "text": "..." } -> ranked labels + cache tier + latency
+//!   GET  /api/info      -> available classifiers (id + taxonomy + totals) + cache
+//!   POST /api/classify  -> { "text": "...", "classifier": "..." }
+//!                          -> ranked labels + cache tier + latency
 
 use std::time::Instant;
 
-use llm_d_sc::classify::{load_and_warm_modelcar, ClassifierRuntime};
+use llm_d_sc::classify::{CandleClassifier, ClassifierRuntime};
 use llm_d_sc::config::CacheConfig;
 use llm_d_sc::grpc::classify::{ClassifyClient, ClassifyRequest, ClassifyServer};
 use llm_d_sc::metrics::MetricsSnapshot;
+use llm_d_sc::taxonomy::ClassifierDefinition;
 
 /// The single-page UI, embedded so the binary is self-contained.
 const INDEX_HTML: &str = include_str!("playground.html");
 
-/// Default per-classifier model directory (matches the CLI convention).
-const DEFAULT_MODEL_DIR: &str = "artifacts/models/complexity";
+/// Base directory holding one ModelCar subdirectory per classifier.
+const DEFAULT_MODELS_DIR: &str = "artifacts/models";
+/// Classifiers offered when the environment does not name a set.
+const DEFAULT_CLASSIFIERS: &str = "complexity,cost,sensitivity";
 /// Default address the browser UI is served on.
 const DEFAULT_UI_ADDR: &str = "127.0.0.1:8080";
 
+/// One resident classifier hosted in-process: its own server, client, the
+/// taxonomy it ranks, and the post-warmup baseline its totals are reported
+/// against.
+struct Classifier {
+    /// Selector key exposed to the UI (the model subdirectory name).
+    name: String,
+    /// Identity the runtime reports (may differ from `name`).
+    classifier_id: String,
+    /// The full ranked taxonomy, captured from the warmup response.
+    labels: Vec<String>,
+    server: ClassifyServer,
+    client: ClassifyClient,
+    baseline: MetricsSnapshot,
+}
+
 fn main() -> std::io::Result<()> {
-    let model_dir =
-        std::env::var("LLM_D_SC_MODEL_DIR").unwrap_or_else(|_| DEFAULT_MODEL_DIR.to_string());
+    let models_dir =
+        std::env::var("LLM_D_SC_MODELS_DIR").unwrap_or_else(|_| DEFAULT_MODELS_DIR.to_string());
+    let names = std::env::var("LLM_D_SC_PLAYGROUND_CLASSIFIERS")
+        .unwrap_or_else(|_| DEFAULT_CLASSIFIERS.to_string());
     let ui_addr =
         std::env::var("LLM_D_SC_PLAYGROUND_ADDR").unwrap_or_else(|_| DEFAULT_UI_ADDR.to_string());
 
-    // Load + warm the resident Candle classifier. ANY failure here (missing
-    // ModelCar dir, bad layout, warmup forward failed) aborts with an
-    // actionable error — a directory that merely exists must not serve.
-    eprintln!("llm-d-sc playground: loading model from {model_dir} …");
-    let classifier = load_and_warm_modelcar(&model_dir).map_err(|e| {
-        std::io::Error::new(
+    // Load + warm every named classifier whose weights are present. A missing
+    // model dir is skipped with a warning rather than fatal, so the demo still
+    // runs with whatever subset is downloaded.
+    let mut classifiers: Vec<Classifier> = Vec::new();
+    for name in names.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let model_dir = format!("{models_dir}/{name}");
+        if !std::path::Path::new(&format!("{model_dir}/model.safetensors")).exists() {
+            eprintln!("llm-d-sc playground: skipping '{name}' — no model at {model_dir}");
+            continue;
+        }
+        match load_classifier(name, &model_dir) {
+            Ok(c) => {
+                eprintln!(
+                    "llm-d-sc playground: loaded '{}' (id '{}', {} labels)",
+                    c.name,
+                    c.classifier_id,
+                    c.labels.len()
+                );
+                classifiers.push(c);
+            }
+            Err(e) => eprintln!("llm-d-sc playground: could not load '{name}': {e}"),
+        }
+    }
+
+    if classifiers.is_empty() {
+        return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            format!("could not load/warm model at {model_dir}: {e}\n\nRun ./hack/fetch-model --classifier complexity (or point LLM_D_SC_MODEL_DIR at a ModelCar dir)."),
-        )
-    })?;
-    let meta = classifier.metadata();
-    let classifier_id = meta.classifier_id.clone();
+            format!(
+                "no classifier models found under {models_dir} (tried: {names}).\n\nRun ./hack/fetch-model --classifier complexity (and cost, sensitivity), or use ./hack/playground."
+            ),
+        ));
+    }
 
-    // Bind the production server in-process. `bind_with_classifier` reads the
-    // cache strategy from the environment (LLM_D_SC_CACHE=redis-semantic +
-    // LLM_D_SC_REDIS_URL), and fails open to the exact cache if Redis is
-    // unreachable or the feature is off — the UI keeps working either way.
-    let server = ClassifyServer::bind_with_classifier("127.0.0.1:0", classifier)?;
-    let grpc_addr = server.local_addr();
-    let mut client = ClassifyClient::connect(&grpc_addr)?;
-
-    // Snapshot of the cache config purely for display in the UI header.
+    // Cache config snapshot, purely for display in the UI header.
     let cache_cfg = CacheConfig::from_env().unwrap_or_else(|_| CacheConfig {
         strategy: "exact".into(),
         redis_url: None,
@@ -71,26 +109,13 @@ fn main() -> std::io::Result<()> {
         timeout_ms: 50,
     });
 
-    // Prime the semantic tier: RediSearch creates its vector index lazily on the
-    // first insert, so the very first lookup hits a not-yet-existent index and
-    // reads as DEGRADED (fail-open). A throwaway warmup classify creates the
-    // index before any user request, and the post-warmup snapshot below becomes
-    // the baseline the UI totals are reported against — so warmup activity stays
-    // invisible and user-facing totals start at zero.
-    let _ = client.classify(ClassifyRequest {
-        request_id: "pg-warmup".to_string(),
-        session_id: "playground".to_string(),
-        context: "llm-d-sc playground warmup probe".to_string(),
-        signals: Vec::new(),
-    });
-    let baseline = server.metrics_snapshot();
-
     let http = tiny_http::Server::http(&ui_addr).map_err(|e| {
         std::io::Error::other(format!("could not bind playground UI on {ui_addr}: {e}"))
     })?;
 
     eprintln!(
-        "llm-d-sc playground: classifier '{classifier_id}', cache strategy '{}', gRPC {grpc_addr}",
+        "llm-d-sc playground: {} classifier(s), cache strategy '{}'",
+        classifiers.len(),
         cache_cfg.strategy
     );
     eprintln!();
@@ -109,20 +134,13 @@ fn main() -> std::io::Result<()> {
             (tiny_http::Method::Get, "/") => {
                 (200, "text/html; charset=utf-8", INDEX_HTML.to_string())
             }
-            (tiny_http::Method::Get, "/api/info") => (
-                200,
-                "application/json",
-                info_json(
-                    &classifier_id,
-                    &cache_cfg,
-                    &server.metrics_snapshot(),
-                    &baseline,
-                ),
-            ),
+            (tiny_http::Method::Get, "/api/info") => {
+                (200, "application/json", info_json(&classifiers, &cache_cfg))
+            }
             (tiny_http::Method::Post, "/api/classify") => {
                 let mut raw = String::new();
                 let _ = request.as_reader().read_to_string(&mut raw);
-                match handle_classify(&mut client, &server, &raw, &mut request_seq, &baseline) {
+                match handle_classify(&mut classifiers, &raw, &mut request_seq) {
                     Ok(json) => (200, "application/json", json),
                     Err(msg) => (200, "application/json", error_json(&msg)),
                 }
@@ -141,20 +159,81 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-/// Run one classify call and describe the outcome, including which cache tier
-/// served it (derived from the metrics counter delta around the call).
+/// Load one classifier, bind it in-process, capture its taxonomy, and snapshot
+/// the post-warmup baseline.
+///
+/// The model weights and the taxonomy are independent: every shipped model is an
+/// embedder ranked against anchor definitions, and the taxonomy (its labels and
+/// `classifier_id`) is selected by name — NOT by the model directory. So each
+/// model dir is paired with its matching built-in definition via
+/// [`ClassifierDefinition::resolve`]; without this every classifier would default
+/// to the same taxonomy and share one cache identity.
+///
+/// The warmup classify does double duty: it primes the RediSearch index (created
+/// lazily on first insert, so the very first lookup would otherwise read as
+/// DEGRADED) and its ranked response reveals the full taxonomy. The baseline
+/// taken afterwards is what UI totals are reported against, so warmup activity
+/// stays invisible and user-facing totals start at zero.
+fn load_classifier(name: &str, model_dir: &str) -> std::io::Result<Classifier> {
+    eprintln!("llm-d-sc playground: loading model from {model_dir} (taxonomy '{name}') …");
+    let definition = ClassifierDefinition::resolve(name).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("no taxonomy definition for '{name}': {e}"),
+        )
+    })?;
+    let classifier =
+        CandleClassifier::from_modelcar_with(std::path::Path::new(model_dir), definition).map_err(
+            |e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("could not load model at {model_dir}: {e}"),
+                )
+            },
+        )?;
+    let classifier_id = classifier.metadata().classifier_id.clone();
+
+    let server = ClassifyServer::bind_with_classifier("127.0.0.1:0", classifier)?;
+    let grpc_addr = server.local_addr();
+    let mut client = ClassifyClient::connect(&grpc_addr)?;
+
+    let warm = client.classify(ClassifyRequest {
+        request_id: format!("pg-warmup-{name}"),
+        session_id: "playground".to_string(),
+        context: "llm-d-sc playground warmup probe".to_string(),
+        signals: Vec::new(),
+    });
+    let labels = warm
+        .map(|r| r.ranked.into_iter().map(|s| s.label).collect())
+        .unwrap_or_default();
+    let baseline = server.metrics_snapshot();
+
+    Ok(Classifier {
+        name: name.to_string(),
+        classifier_id,
+        labels,
+        server,
+        client,
+        baseline,
+    })
+}
+
+/// Run one classify call against the requested classifier and describe the
+/// outcome, including which cache tier served it (derived from that server's
+/// metrics counter delta around the call).
 fn handle_classify(
-    client: &mut ClassifyClient,
-    server: &ClassifyServer,
+    classifiers: &mut [Classifier],
     raw_body: &str,
     seq: &mut u64,
-    baseline: &MetricsSnapshot,
 ) -> Result<String, String> {
-    let text =
-        parse_text(raw_body).ok_or_else(|| "request body must be {\"text\": \"…\"}".to_string())?;
+    let (text, which) = parse_request(raw_body)?;
     if text.trim().is_empty() {
         return Err("prompt text is empty".to_string());
     }
+    let entry = classifiers
+        .iter_mut()
+        .find(|c| c.name == which)
+        .ok_or_else(|| format!("unknown classifier '{which}'"))?;
 
     *seq += 1;
     let request = ClassifyRequest {
@@ -165,16 +244,24 @@ fn handle_classify(
         signals: Vec::new(),
     };
 
-    let before = server.metrics_snapshot();
+    let before = entry.server.metrics_snapshot();
     let started = Instant::now();
-    let response = client
+    let response = entry
+        .client
         .classify(request)
         .map_err(|s| format!("classify failed: {} ({})", s.message(), s.code()))?;
     let latency_ms = started.elapsed().as_secs_f64() * 1000.0;
-    let after = server.metrics_snapshot();
+    let after = entry.server.metrics_snapshot();
 
     let tier = classify_tier(&before, &after);
-    Ok(response_json(&response, tier, latency_ms, &after, baseline))
+    Ok(response_json(
+        &entry.name,
+        &response,
+        tier,
+        latency_ms,
+        &after,
+        &entry.baseline,
+    ))
 }
 
 /// Partition a served request into a cache tier from the counter delta.
@@ -197,10 +284,22 @@ fn classify_tier(before: &MetricsSnapshot, after: &MetricsSnapshot) -> &'static 
     }
 }
 
-/// Extract the `text` field from a `{"text": "..."}` JSON body.
-fn parse_text(raw: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
-    v.get("text")?.as_str().map(|s| s.to_string())
+/// Extract `text` (required) and `classifier` (defaults to the first built-in)
+/// from a `{"text": "...", "classifier": "..."}` JSON body.
+fn parse_request(raw: &str) -> Result<(String, String), String> {
+    let v: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| "request body must be JSON".to_string())?;
+    let text = v
+        .get("text")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| "request body must be {\"text\": \"…\"}".to_string())?
+        .to_string();
+    let which = v
+        .get("classifier")
+        .and_then(|c| c.as_str())
+        .unwrap_or("complexity")
+        .to_string();
+    Ok((text, which))
 }
 
 /// Human-readable name for a proto `ClassificationStatus` discriminant.
@@ -226,6 +325,7 @@ fn totals_json(snap: &MetricsSnapshot, baseline: &MetricsSnapshot) -> serde_json
 }
 
 fn response_json(
+    classifier: &str,
     response: &llm_d_sc::grpc::classify::ClassifyResponse,
     tier: &str,
     latency_ms: f64,
@@ -238,6 +338,7 @@ fn response_json(
         .map(|r| serde_json::json!({ "label": r.label, "score": r.score }))
         .collect();
     serde_json::json!({
+        "classifier": classifier,
         "tier": tier,
         "latency_ms": format!("{latency_ms:.1}"),
         "status": status_name(response.status),
@@ -251,18 +352,23 @@ fn response_json(
     .to_string()
 }
 
-fn info_json(
-    classifier_id: &str,
-    cfg: &CacheConfig,
-    totals: &MetricsSnapshot,
-    baseline: &MetricsSnapshot,
-) -> String {
+fn info_json(classifiers: &[Classifier], cfg: &CacheConfig) -> String {
+    let list: Vec<serde_json::Value> = classifiers
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "name": c.name,
+                "classifier_id": c.classifier_id,
+                "labels": c.labels,
+                "totals": totals_json(&c.server.metrics_snapshot(), &c.baseline),
+            })
+        })
+        .collect();
     serde_json::json!({
-        "classifier_id": classifier_id,
         "cache_strategy": cfg.strategy,
         "redis_url": cfg.redis_url,
         "threshold": cfg.threshold,
-        "totals": totals_json(totals, baseline),
+        "classifiers": list,
     })
     .to_string()
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,6 +19,8 @@
 //! The cache stores the typed [`crate::classify::ClassificationResult`], not a
 //! `String`.
 
+pub mod breaker;
+
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Condvar, Mutex};

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,6 +29,10 @@ pub mod breaker;
 pub mod redis;
 #[cfg(feature = "redis-semantic")]
 pub mod redis_codec;
+// Semantic cache for full LLM responses (playground/gateway use). Reuses the
+// RediSearch vector-KNN machinery in a separate index/namespace.
+#[cfg(feature = "redis-semantic")]
+pub mod response;
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,6 +20,7 @@
 //! `String`.
 
 pub mod breaker;
+pub mod redis;
 pub mod redis_codec;
 
 use std::collections::HashMap;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Condvar, Mutex};
 
-use crate::classify::{ClassificationResult, ClassifyError};
+use crate::classify::{ClassificationResult, ClassifyError, Embedding};
 
 /// A versioned fingerprint cache key (design.md).
 ///
@@ -349,6 +349,38 @@ impl Default for ExactCache {
     }
 }
 
+/// The pluggable L2 (semantic / approximate) cache seam.
+///
+/// Interposes on the embedding between `embed` and `rank`. It is BEST-EFFORT:
+/// `lookup` returns `None` on any error (fail-open to compute) and `insert`
+/// is fire-and-forget. `identity` isolates entries by classifier/model/
+/// tokenizer/taxonomy so a revision change can never serve a stale label.
+pub trait SemanticCache: Send + Sync {
+    /// Return a stored result whose embedding is within the configured
+    /// similarity threshold of `embedding` and shares `identity`, else `None`.
+    fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult>;
+
+    /// Record `result` under `embedding` and `identity`. Best-effort; never blocks.
+    fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str);
+}
+
+/// The default L2 cache: always misses, never stores. Zero cost when the
+/// semantic tier is disabled.
+pub struct NoopSemanticCache;
+
+impl SemanticCache for NoopSemanticCache {
+    fn lookup(&self, _embedding: &Embedding, _identity: &str) -> Option<ClassificationResult> {
+        None
+    }
+    fn insert(&self, _embedding: &Embedding, _result: &ClassificationResult, _identity: &str) {}
+}
+
+/// Build the L2 isolation tag from a cache-identity tuple (same fields as the
+/// blake3 L1 key), pipe-separated so field boundaries cannot alias.
+pub fn identity_tag(id: (&str, &str, &str, &str)) -> String {
+    format!("{}|{}|{}|{}", id.0, id.1, id.2, id.3)
+}
+
 #[cfg(test)]
 mod bounded_tests {
     use super::*;
@@ -628,6 +660,46 @@ mod tests {
                 .iter()
                 .all(|r| matches!(r, Ok(c) if c.ranked.first().map(|s| s.id.as_str()) == Some("sensitivity"))),
             "every concurrent caller must receive the same classification result"
+        );
+    }
+}
+
+#[cfg(test)]
+mod semantic_tests {
+    use super::*;
+    use crate::classify::{ClassifyStatus, RankedSignal};
+
+    fn result(id: &str) -> ClassificationResult {
+        ClassificationResult {
+            classifier_id: "c".into(),
+            model_revision: "m".into(),
+            tokenizer_revision: "t".into(),
+            taxonomy_revision: "x".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal {
+                id: id.into(),
+                score: 1.0,
+            }],
+        }
+    }
+
+    #[test]
+    fn noop_semantic_cache_never_hits() {
+        let cache = NoopSemanticCache;
+        let e = Embedding::new(vec![1.0, 0.0]);
+        cache.insert(&e, &result("simple"), "c|m|t|x");
+        assert!(
+            cache.lookup(&e, "c|m|t|x").is_none(),
+            "noop must always miss"
+        );
+    }
+
+    #[test]
+    fn identity_tag_is_stable_and_field_separated() {
+        assert_eq!(identity_tag(("c", "m", "t", "x")), "c|m|t|x");
+        assert_ne!(
+            identity_tag(("a", "bc", "d", "e")),
+            identity_tag(("ab", "c", "d", "e"))
         );
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,6 +20,7 @@
 //! `String`.
 
 pub mod breaker;
+pub mod redis_codec;
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,8 +19,15 @@
 //! The cache stores the typed [`crate::classify::ClassificationResult`], not a
 //! `String`.
 
+// The Redis semantic (L2) backend and its supporting modules are compiled only
+// when the `redis-semantic` feature is enabled. The `SemanticCache` trait,
+// `NoopSemanticCache`, and `identity_tag` below stay always-compiled — they are
+// the seam `ServiceCore` uses, defaulting to the Noop (off) cache.
+#[cfg(feature = "redis-semantic")]
 pub mod breaker;
+#[cfg(feature = "redis-semantic")]
 pub mod redis;
+#[cfg(feature = "redis-semantic")]
 pub mod redis_codec;
 
 use std::collections::HashMap;

--- a/src/cache/breaker.rs
+++ b/src/cache/breaker.rs
@@ -1,0 +1,83 @@
+//! A minimal consecutive-failure circuit breaker for the best-effort L2 cache.
+//! After `failure_threshold` consecutive failures it opens for `cooldown`,
+//! so a dead Redis costs one probe per cooldown window, not one per request.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+struct State {
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
+}
+
+pub struct CircuitBreaker {
+    failure_threshold: u32,
+    cooldown: Duration,
+    state: Mutex<State>,
+}
+
+impl CircuitBreaker {
+    pub fn new(failure_threshold: u32, cooldown: Duration) -> Self {
+        CircuitBreaker {
+            failure_threshold: failure_threshold.max(1),
+            cooldown,
+            state: Mutex::new(State { consecutive_failures: 0, open_until: None }),
+        }
+    }
+
+    /// True if a call may proceed (closed, or half-open after cooldown).
+    pub fn allow(&self) -> bool {
+        let mut s = self.state.lock().unwrap();
+        match s.open_until {
+            Some(t) if Instant::now() < t => false,
+            Some(_) => {
+                // Cooldown elapsed: half-open, let one probe through.
+                s.open_until = None;
+                s.consecutive_failures = 0;
+                true
+            }
+            None => true,
+        }
+    }
+
+    pub fn record_success(&self) {
+        let mut s = self.state.lock().unwrap();
+        s.consecutive_failures = 0;
+        s.open_until = None;
+    }
+
+    pub fn record_failure(&self) {
+        let mut s = self.state.lock().unwrap();
+        s.consecutive_failures += 1;
+        if s.consecutive_failures >= self.failure_threshold {
+            s.open_until = Some(Instant::now() + self.cooldown);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn opens_after_threshold_and_closes_after_cooldown() {
+        let cb = CircuitBreaker::new(2, Duration::from_millis(50));
+        assert!(cb.allow(), "starts closed");
+        cb.record_failure();
+        assert!(cb.allow(), "one failure below threshold");
+        cb.record_failure();
+        assert!(!cb.allow(), "opens at threshold");
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(cb.allow(), "closes (half-open) after cooldown");
+    }
+
+    #[test]
+    fn success_resets_failures() {
+        let cb = CircuitBreaker::new(2, Duration::from_secs(10));
+        cb.record_failure();
+        cb.record_success();
+        cb.record_failure();
+        assert!(cb.allow(), "success cleared the earlier failure");
+    }
+}

--- a/src/cache/breaker.rs
+++ b/src/cache/breaker.rs
@@ -21,7 +21,10 @@ impl CircuitBreaker {
         CircuitBreaker {
             failure_threshold: failure_threshold.max(1),
             cooldown,
-            state: Mutex::new(State { consecutive_failures: 0, open_until: None }),
+            state: Mutex::new(State {
+                consecutive_failures: 0,
+                open_until: None,
+            }),
         }
     }
 

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -3,6 +3,7 @@
 //! or a dropped write (insert). Guarded by a circuit breaker so a dead Redis
 //! costs one probe per cooldown, not one timeout per request.
 
+use std::sync::mpsc::{sync_channel, SyncSender};
 use std::time::Duration;
 
 use r2d2::Pool;
@@ -17,13 +18,27 @@ use crate::classify::{ClassificationResult, Embedding};
 use crate::config::CacheConfig;
 use crate::metrics::Metrics;
 
+/// A deferred L2 write, enqueued by `insert` and drained by the background
+/// write-back worker so the caller never blocks on Redis.
+enum WriteJob {
+    Put {
+        blob: Vec<u8>,
+        dim: usize,
+        payload: String,
+        identity: String,
+    },
+}
+
 pub struct RedisSemanticCache {
     pool: Pool<Client>,
     threshold: f32,
-    ttl_secs: u64,
     timeout_ms: u64,
     breaker: CircuitBreaker,
     metrics: Metrics,
+    /// Enqueues writes for the background `sc-l2-writeback` worker. Bounded
+    /// so a Redis outage cannot grow unbounded memory; a full queue drops
+    /// the write (best-effort, same fail-open contract as a Redis error).
+    writer: SyncSender<WriteJob>,
 }
 
 impl RedisSemanticCache {
@@ -44,13 +59,106 @@ impl RedisSemanticCache {
             .connection_timeout(Duration::from_millis(cfg.timeout_ms))
             .build(client)
             .map_err(|e| e.to_string())?;
+
+        // Bounded so a sustained Redis outage cannot grow the queue without
+        // limit; `insert` drops the write (best-effort) once it is full.
+        let (tx, rx) = sync_channel::<WriteJob>(1024);
+        {
+            let pool = pool.clone();
+            let metrics = metrics.clone();
+            let ttl = cfg.ttl_secs;
+            let timeout_ms = cfg.timeout_ms;
+            std::thread::Builder::new()
+                .name("sc-l2-writeback".into())
+                .spawn(move || {
+                    // Its own breaker: a wedged Redis must not have the
+                    // writer hammering it once per queued job, independent
+                    // of the reader-side breaker's state.
+                    let breaker = CircuitBreaker::new(5, Duration::from_secs(10));
+                    for job in rx {
+                        if !breaker.allow() {
+                            // An open breaker means this write is dropped
+                            // exactly like a real failure: count it as
+                            // degraded, not a silent no-op.
+                            metrics.record_l2_degraded();
+                            continue;
+                        }
+                        let WriteJob::Put {
+                            blob,
+                            dim,
+                            payload,
+                            identity,
+                        } = job;
+                        let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
+                        let write = (|| -> Result<(), String> {
+                            let mut conn = pool.get().map_err(|e| e.to_string())?;
+                            let timeout = Duration::from_millis(timeout_ms);
+                            conn.set_read_timeout(Some(timeout)).ok();
+                            conn.set_write_timeout(Some(timeout)).ok();
+                            // Create the index lazily now that the vector
+                            // dimension is known. Ignore the result: an
+                            // "already exists" error (or any other trouble)
+                            // here only means lookups may miss, never that
+                            // this write-back fails.
+                            let _ = redis::cmd("FT.CREATE")
+                                .arg(index_name())
+                                .arg("ON")
+                                .arg("HASH")
+                                .arg("PREFIX")
+                                .arg(1)
+                                .arg("sc:")
+                                .arg("SCHEMA")
+                                .arg("identity")
+                                .arg("TAG")
+                                .arg("payload")
+                                .arg("TEXT")
+                                .arg("vec")
+                                .arg("VECTOR")
+                                .arg("FLAT")
+                                .arg(6)
+                                .arg("TYPE")
+                                .arg("FLOAT32")
+                                .arg("DIM")
+                                .arg(dim)
+                                .arg("DISTANCE_METRIC")
+                                .arg("COSINE")
+                                .query::<redis::Value>(&mut conn);
+                            redis::cmd("HSET")
+                                .arg(&key)
+                                .arg("identity")
+                                .arg(&identity)
+                                .arg("payload")
+                                .arg(&payload)
+                                .arg("vec")
+                                .arg(blob.as_slice())
+                                .query::<redis::Value>(&mut conn)
+                                .map_err(|e| e.to_string())?;
+                            redis::cmd("EXPIRE")
+                                .arg(&key)
+                                .arg(ttl)
+                                .query::<redis::Value>(&mut conn)
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        })();
+                        match write {
+                            Ok(_) => breaker.record_success(),
+                            Err(_) => {
+                                breaker.record_failure();
+                                metrics.record_l2_degraded();
+                            }
+                        }
+                    }
+                })
+                .map_err(|e| e.to_string())?;
+        }
+
         let cache = RedisSemanticCache {
             pool,
             threshold: cfg.threshold,
-            ttl_secs: cfg.ttl_secs,
             timeout_ms: cfg.timeout_ms,
             breaker: CircuitBreaker::new(5, Duration::from_secs(10)),
             metrics,
+            writer: tx,
         };
         // Best-effort index creation; a missing index only means lookups miss.
         // The dimension is not known until the first insert (RediSearch
@@ -162,62 +270,25 @@ impl SemanticCache for RedisSemanticCache {
             self.metrics.record_l2_degraded();
             return;
         }
-        let blob = vector_to_bytes(&embedding.vector);
-        let dim = embedding.dim();
-        let payload = encode_result(result);
-        let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
-        let ttl = self.ttl_secs;
-        // `with_timeout_conn` runs `f` synchronously in this same call (no
-        // spawned thread), so the closure can borrow `identity` directly —
-        // no need to own a cloned String.
-        let outcome = self.with_timeout_conn(move |conn| {
-            // Create the index lazily now that the vector dimension is known.
-            // Ignore the result: an "already exists" error (or any other
-            // trouble) here only means lookups may miss, never that the
-            // caller's request fails.
-            let _ = redis::cmd("FT.CREATE")
-                .arg(index_name())
-                .arg("ON")
-                .arg("HASH")
-                .arg("PREFIX")
-                .arg(1)
-                .arg("sc:")
-                .arg("SCHEMA")
-                .arg("identity")
-                .arg("TAG")
-                .arg("payload")
-                .arg("TEXT")
-                .arg("vec")
-                .arg("VECTOR")
-                .arg("FLAT")
-                .arg(6)
-                .arg("TYPE")
-                .arg("FLOAT32")
-                .arg("DIM")
-                .arg(dim)
-                .arg("DISTANCE_METRIC")
-                .arg("COSINE")
-                .query::<redis::Value>(conn);
-            redis::cmd("HSET")
-                .arg(&key)
-                .arg("identity")
-                .arg(identity)
-                .arg("payload")
-                .arg(&payload)
-                .arg("vec")
-                .arg(blob.as_slice())
-                .query::<redis::Value>(conn)?;
-            redis::cmd("EXPIRE")
-                .arg(&key)
-                .arg(ttl)
-                .query::<redis::Value>(conn)
-        });
-        match outcome {
-            Ok(_) => self.breaker.record_success(),
-            Err(_) => {
-                self.breaker.record_failure();
-                self.metrics.record_l2_degraded();
-            }
+        // `encode_result` uses `serde_json`'s panicking encoder, and JSON
+        // cannot represent NaN/Infinity: a non-finite score would panic this
+        // (the caller's/inference) thread. Drop the write-back instead —
+        // the same fail-open contract as any other write failure.
+        if result.ranked.iter().any(|r| !r.score.is_finite()) {
+            self.metrics.record_l2_degraded();
+            return;
+        }
+        let job = WriteJob::Put {
+            blob: vector_to_bytes(&embedding.vector),
+            dim: embedding.dim(),
+            payload: encode_result(result),
+            identity: identity.to_string(),
+        };
+        // Best-effort: enqueue and return immediately. A full queue drops
+        // the write rather than blocking the caller on Redis; that dropped
+        // write-back is observably degraded, same as any other L2 failure.
+        if self.writer.try_send(job).is_err() {
+            self.metrics.record_l2_degraded();
         }
     }
 }

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -77,6 +77,10 @@ impl RedisSemanticCache {
     ) -> Result<T, String> {
         let mut conn = self.pool.get().map_err(|e| e.to_string())?;
         let timeout = Duration::from_millis(self.timeout_ms);
+        // Best-effort: if the underlying socket refuses the timeout setting,
+        // tolerate it rather than failing the request — the per-op timeout is
+        // a defense-in-depth guard, not the only thing standing between a
+        // hung Redis and the caller (the circuit breaker is the backstop).
         conn.set_read_timeout(Some(timeout)).ok();
         conn.set_write_timeout(Some(timeout)).ok();
         f(&mut conn).map_err(|e| e.to_string())
@@ -86,6 +90,9 @@ impl RedisSemanticCache {
 impl SemanticCache for RedisSemanticCache {
     fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult> {
         if !self.breaker.allow() {
+            // An open breaker means Redis is treated as unavailable right
+            // now: count it as a degraded L2 op, same as a real failure.
+            self.metrics.record_l2_degraded();
             return None;
         }
         let blob = vector_to_bytes(&embedding.vector);
@@ -150,6 +157,9 @@ impl SemanticCache for RedisSemanticCache {
 
     fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str) {
         if !self.breaker.allow() {
+            // An open breaker means Redis is treated as unavailable right
+            // now: count it as a degraded L2 op, same as a real failure.
+            self.metrics.record_l2_degraded();
             return;
         }
         let blob = vector_to_bytes(&embedding.vector);
@@ -157,7 +167,9 @@ impl SemanticCache for RedisSemanticCache {
         let payload = encode_result(result);
         let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
         let ttl = self.ttl_secs;
-        let identity = identity.to_string();
+        // `with_timeout_conn` runs `f` synchronously in this same call (no
+        // spawned thread), so the closure can borrow `identity` directly —
+        // no need to own a cloned String.
         let outcome = self.with_timeout_conn(move |conn| {
             // Create the index lazily now that the vector dimension is known.
             // Ignore the result: an "already exists" error (or any other
@@ -189,7 +201,7 @@ impl SemanticCache for RedisSemanticCache {
             redis::cmd("HSET")
                 .arg(&key)
                 .arg("identity")
-                .arg(&identity)
+                .arg(identity)
                 .arg("payload")
                 .arg(&payload)
                 .arg("vec")

--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -1,0 +1,314 @@
+//! Redis Stack (RediSearch) semantic cache. BEST-EFFORT and FAIL-OPEN: every
+//! Redis interaction is wrapped so any error/timeout yields "no hit" (lookup)
+//! or a dropped write (insert). Guarded by a circuit breaker so a dead Redis
+//! costs one probe per cooldown, not one timeout per request.
+
+use std::time::Duration;
+
+use r2d2::Pool;
+use redis::Client;
+
+use crate::cache::breaker::CircuitBreaker;
+use crate::cache::redis_codec::{
+    cosine_score_from_distance, decode_result, encode_result, index_name, vector_to_bytes,
+};
+use crate::cache::SemanticCache;
+use crate::classify::{ClassificationResult, Embedding};
+use crate::config::CacheConfig;
+use crate::metrics::Metrics;
+
+pub struct RedisSemanticCache {
+    pool: Pool<Client>,
+    threshold: f32,
+    ttl_secs: u64,
+    timeout_ms: u64,
+    breaker: CircuitBreaker,
+    metrics: Metrics,
+}
+
+impl RedisSemanticCache {
+    /// Connect, size the pool small (matches the inference pool width), set
+    /// per-op timeouts, and ensure the vector index exists.
+    pub fn connect(cfg: &CacheConfig, metrics: Metrics) -> Result<RedisSemanticCache, String> {
+        let url = cfg
+            .redis_url
+            .as_ref()
+            .ok_or("redis-semantic requires a URL")?;
+        let client = Client::open(url.as_str()).map_err(|e| e.to_string())?;
+        let pool = Pool::builder()
+            .max_size(8)
+            // Do not eagerly dial Redis at build time: a currently-unreachable
+            // Redis must not prevent the service from starting (fail-open).
+            // Connections are established lazily on the first `pool.get()`.
+            .min_idle(Some(0))
+            .connection_timeout(Duration::from_millis(cfg.timeout_ms))
+            .build(client)
+            .map_err(|e| e.to_string())?;
+        let cache = RedisSemanticCache {
+            pool,
+            threshold: cfg.threshold,
+            ttl_secs: cfg.ttl_secs,
+            timeout_ms: cfg.timeout_ms,
+            breaker: CircuitBreaker::new(5, Duration::from_secs(10)),
+            metrics,
+        };
+        // Best-effort index creation; a missing index only means lookups miss.
+        // The dimension is not known until the first insert (RediSearch
+        // requires DIM at FT.CREATE time), so the index is actually created
+        // lazily in `insert`. This call is kept for symmetry with `connect`
+        // establishing everything it can up front.
+        let _ = cache.ensure_index();
+        Ok(cache)
+    }
+
+    /// Placeholder for eager index creation. See the comment in `connect`:
+    /// the index needs a vector DIM that is only known once the first
+    /// embedding is inserted, so real creation happens lazily in `insert`.
+    fn ensure_index(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Check out a pooled connection, apply the per-op timeout, and run `f`.
+    /// Any pool/connection/command error is collapsed to a `String` so the
+    /// caller can treat it uniformly as "Redis is unavailable right now".
+    fn with_timeout_conn<T>(
+        &self,
+        f: impl FnOnce(&mut redis::Connection) -> redis::RedisResult<T>,
+    ) -> Result<T, String> {
+        let mut conn = self.pool.get().map_err(|e| e.to_string())?;
+        let timeout = Duration::from_millis(self.timeout_ms);
+        conn.set_read_timeout(Some(timeout)).ok();
+        conn.set_write_timeout(Some(timeout)).ok();
+        f(&mut conn).map_err(|e| e.to_string())
+    }
+}
+
+impl SemanticCache for RedisSemanticCache {
+    fn lookup(&self, embedding: &Embedding, identity: &str) -> Option<ClassificationResult> {
+        if !self.breaker.allow() {
+            return None;
+        }
+        let blob = vector_to_bytes(&embedding.vector);
+        // FT.SEARCH sc_semantic_idx "(@identity:{<tag>})=>[KNN 1 @vec $BLOB AS dist]"
+        //   PARAMS 2 BLOB <blob> DIALECT 2 SORTBY dist RETURN 2 dist payload
+        let query = format!(
+            "(@identity:{{{}}})=>[KNN 1 @vec $BLOB AS dist]",
+            escape_tag_value(identity)
+        );
+        let outcome = self.with_timeout_conn(|conn| {
+            redis::cmd("FT.SEARCH")
+                .arg(index_name())
+                .arg(&query)
+                .arg("PARAMS")
+                .arg(2)
+                .arg("BLOB")
+                .arg(blob.as_slice())
+                .arg("SORTBY")
+                .arg("dist")
+                .arg("RETURN")
+                .arg(2)
+                .arg("dist")
+                .arg("payload")
+                .arg("DIALECT")
+                .arg(2)
+                .query::<redis::Value>(conn)
+        });
+        match outcome {
+            Ok(value) => {
+                self.breaker.record_success();
+                match parse_knn_reply(&value) {
+                    Some((distance, payload))
+                        if cosine_score_from_distance(distance) >= self.threshold =>
+                    {
+                        // A malformed stored payload is a corrupt reply, not a
+                        // hit: recording a hit here would claim a result was
+                        // served when `None` is actually returned.
+                        match decode_result(&payload) {
+                            Some(result) => {
+                                self.metrics.record_l2_hit();
+                                Some(result)
+                            }
+                            None => {
+                                self.metrics.record_l2_degraded();
+                                None
+                            }
+                        }
+                    }
+                    _ => {
+                        self.metrics.record_l2_miss();
+                        None
+                    }
+                }
+            }
+            Err(_) => {
+                self.breaker.record_failure();
+                self.metrics.record_l2_degraded();
+                None
+            }
+        }
+    }
+
+    fn insert(&self, embedding: &Embedding, result: &ClassificationResult, identity: &str) {
+        if !self.breaker.allow() {
+            return;
+        }
+        let blob = vector_to_bytes(&embedding.vector);
+        let dim = embedding.dim();
+        let payload = encode_result(result);
+        let key = format!("sc:{identity}:{}", blake3::hash(&blob).to_hex());
+        let ttl = self.ttl_secs;
+        let identity = identity.to_string();
+        let outcome = self.with_timeout_conn(move |conn| {
+            // Create the index lazily now that the vector dimension is known.
+            // Ignore the result: an "already exists" error (or any other
+            // trouble) here only means lookups may miss, never that the
+            // caller's request fails.
+            let _ = redis::cmd("FT.CREATE")
+                .arg(index_name())
+                .arg("ON")
+                .arg("HASH")
+                .arg("PREFIX")
+                .arg(1)
+                .arg("sc:")
+                .arg("SCHEMA")
+                .arg("identity")
+                .arg("TAG")
+                .arg("payload")
+                .arg("TEXT")
+                .arg("vec")
+                .arg("VECTOR")
+                .arg("FLAT")
+                .arg(6)
+                .arg("TYPE")
+                .arg("FLOAT32")
+                .arg("DIM")
+                .arg(dim)
+                .arg("DISTANCE_METRIC")
+                .arg("COSINE")
+                .query::<redis::Value>(conn);
+            redis::cmd("HSET")
+                .arg(&key)
+                .arg("identity")
+                .arg(&identity)
+                .arg("payload")
+                .arg(&payload)
+                .arg("vec")
+                .arg(blob.as_slice())
+                .query::<redis::Value>(conn)?;
+            redis::cmd("EXPIRE")
+                .arg(&key)
+                .arg(ttl)
+                .query::<redis::Value>(conn)
+        });
+        match outcome {
+            Ok(_) => self.breaker.record_success(),
+            Err(_) => {
+                self.breaker.record_failure();
+                self.metrics.record_l2_degraded();
+            }
+        }
+    }
+}
+
+/// Escape characters RediSearch treats as query syntax inside a TAG value, so
+/// an identity tag containing '.', '-', or similar (e.g. a semver revision)
+/// is matched literally rather than parsed as query syntax.
+fn escape_tag_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            out.push(c);
+        } else {
+            out.push('\\');
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Extract (distance, payload) from a RediSearch FT.SEARCH reply, or None if the
+/// reply shape is empty/unexpected. Fail-open: any parse surprise is a miss.
+fn parse_knn_reply(value: &redis::Value) -> Option<(f32, String)> {
+    // FT.SEARCH returns: [count, key, [field, val, field, val, ...], ...]
+    if let redis::Value::Array(items) = value {
+        // items[0] = count; the field array is the 3rd element (index 2).
+        if let Some(redis::Value::Array(fields)) = items.get(2) {
+            let mut dist: Option<f32> = None;
+            let mut payload: Option<String> = None;
+            let mut i = 0;
+            while i + 1 < fields.len() {
+                let name = as_string(&fields[i]);
+                let val = as_string(&fields[i + 1]);
+                match name.as_deref() {
+                    Some("dist") => dist = val.and_then(|s| s.parse::<f32>().ok()),
+                    Some("payload") => payload = val,
+                    _ => {}
+                }
+                i += 2;
+            }
+            if let (Some(d), Some(p)) = (dist, payload) {
+                return Some((d, p));
+            }
+        }
+    }
+    None
+}
+
+fn as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(bytes) => Some(String::from_utf8_lossy(bytes).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A well-formed FT.SEARCH KNN-1 reply: `[count, key, [field, val, ...]]`.
+    fn knn_reply(dist: &str, payload: &str) -> redis::Value {
+        redis::Value::Array(vec![
+            redis::Value::Int(1),
+            redis::Value::BulkString(b"sc:some-key".to_vec()),
+            redis::Value::Array(vec![
+                redis::Value::BulkString(b"dist".to_vec()),
+                redis::Value::BulkString(dist.as_bytes().to_vec()),
+                redis::Value::BulkString(b"payload".to_vec()),
+                redis::Value::BulkString(payload.as_bytes().to_vec()),
+            ]),
+        ])
+    }
+
+    #[test]
+    fn parse_knn_reply_extracts_distance_and_payload() {
+        let value = knn_reply("0.05", "{\"ok\":true}");
+        let (dist, payload) = parse_knn_reply(&value).expect("well-formed reply must parse");
+        assert!((dist - 0.05).abs() < 1e-6);
+        assert_eq!(payload, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn parse_knn_reply_is_none_on_empty_result_set() {
+        // FT.SEARCH with no matches replies just `[0]` — a clean miss, not a
+        // malformed reply.
+        let value = redis::Value::Array(vec![redis::Value::Int(0)]);
+        assert!(parse_knn_reply(&value).is_none());
+    }
+
+    #[test]
+    fn parse_knn_reply_is_none_on_unexpected_shape() {
+        // Fail-open: any reply shape parse_knn_reply doesn't recognize is a miss.
+        assert!(parse_knn_reply(&redis::Value::Okay).is_none());
+        assert!(parse_knn_reply(&redis::Value::Nil).is_none());
+    }
+
+    #[test]
+    fn escape_tag_value_escapes_non_alphanumeric_characters() {
+        assert_eq!(escape_tag_value("complexity"), "complexity");
+        assert_eq!(
+            escape_tag_value("complexity|m-1.0|t|x"),
+            "complexity\\|m\\-1\\.0\\|t\\|x"
+        );
+    }
+}

--- a/src/cache/redis_codec.rs
+++ b/src/cache/redis_codec.rs
@@ -1,0 +1,83 @@
+//! Pure (no-I/O) codec + query-shape helpers for the Redis semantic cache, so
+//! the byte encoding, index name, and result serialization are unit-testable
+//! without a live Redis.
+
+use crate::classify::ClassificationResult;
+
+/// The RediSearch index over the semantic-cache hash keys.
+pub fn index_name() -> &'static str {
+    "sc_semantic_idx"
+}
+
+/// Encode an embedding as the little-endian f32 blob RediSearch expects for a
+/// FLOAT32 vector field.
+pub fn vector_to_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+/// Serialize a classification result for storage.
+pub fn encode_result(r: &ClassificationResult) -> String {
+    serde_json::to_string(r).expect("ClassificationResult serializes")
+}
+
+/// Deserialize a stored result; `None` on any corruption (treated as a miss).
+pub fn decode_result(s: &str) -> Option<ClassificationResult> {
+    serde_json::from_str(s).ok()
+}
+
+/// RediSearch returns COSINE *distance* (0 = identical). Convert to a
+/// similarity score in [0, 1] for threshold comparison.
+pub fn cosine_score_from_distance(distance: f32) -> f32 {
+    1.0 - distance
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify::{ClassificationResult, ClassifyStatus, RankedSignal};
+
+    #[test]
+    fn vector_bytes_are_little_endian_f32() {
+        let bytes = vector_to_bytes(&[1.0f32, 2.0f32]);
+        assert_eq!(bytes.len(), 8);
+        assert_eq!(&bytes[0..4], &1.0f32.to_le_bytes());
+        assert_eq!(&bytes[4..8], &2.0f32.to_le_bytes());
+    }
+
+    #[test]
+    fn result_round_trips_through_json() {
+        let r = ClassificationResult {
+            classifier_id: "complexity".into(),
+            model_revision: "m".into(),
+            tokenizer_revision: "t".into(),
+            taxonomy_revision: "x".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal {
+                id: "SIMPLE".into(),
+                score: 0.87,
+            }],
+        };
+        let encoded = encode_result(&r);
+        let decoded = decode_result(&encoded).expect("decode");
+        assert_eq!(decoded, r);
+    }
+
+    #[test]
+    fn cosine_score_is_one_minus_distance() {
+        assert!((cosine_score_from_distance(0.1) - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bad_json_decodes_to_none() {
+        assert!(decode_result("not json").is_none());
+    }
+
+    #[test]
+    fn index_name_is_stable() {
+        assert_eq!(index_name(), "sc_semantic_idx");
+    }
+}

--- a/src/cache/response.rs
+++ b/src/cache/response.rs
@@ -1,0 +1,274 @@
+//! Semantic **response** cache (L2 for completions).
+//!
+//! The classification L2 cache ([`crate::cache::redis`]) stores a
+//! `ClassificationResult` keyed by a prompt embedding. This module reuses the
+//! same Redis Stack / RediSearch vector-KNN machinery to cache the far more
+//! expensive artifact: the LLM's chat-completion response itself.
+//!
+//! It is deliberately kept in a **separate** RediSearch index
+//! (`resp_semantic_idx`) and key namespace (`resp:`) so it never collides with
+//! the classification cache — both can live in one Redis. The payload is the
+//! raw upstream completion JSON, and the identity tag is the model name, so a
+//! near-duplicate prompt to the *same* model can be served from cache while a
+//! different model still misses.
+//!
+//! Everything here is best-effort and fail-open: any Redis error is a cache
+//! miss (on lookup) or a silently-dropped write (on insert). Inference
+//! correctness never depends on the cache being up.
+
+use std::time::Duration;
+
+use r2d2::Pool;
+use redis::Client;
+
+use crate::cache::redis_codec::{cosine_score_from_distance, vector_to_bytes};
+
+/// RediSearch index for the response cache, distinct from the classification
+/// index (`sc_semantic_idx`) so the two never share documents.
+fn resp_index_name() -> &'static str {
+    "resp_semantic_idx"
+}
+
+/// A semantic cache for full chat-completion responses.
+pub struct RedisResponseCache {
+    pool: Pool<Client>,
+    threshold: f32,
+    ttl_secs: u64,
+    timeout: Duration,
+}
+
+impl RedisResponseCache {
+    /// Connect and build a small connection pool. Returns an error only for a
+    /// malformed URL or pool-construction failure; a *reachable* Redis is not
+    /// required at construction time (operations fail open later).
+    pub fn connect(
+        redis_url: &str,
+        threshold: f32,
+        ttl_secs: u64,
+        timeout_ms: u64,
+    ) -> Result<Self, String> {
+        let timeout = Duration::from_millis(timeout_ms.max(50));
+        let client = Client::open(redis_url).map_err(|e| e.to_string())?;
+        let pool = Pool::builder()
+            .max_size(4)
+            .min_idle(Some(0))
+            .connection_timeout(timeout)
+            .build(client)
+            .map_err(|e| e.to_string())?;
+        Ok(Self {
+            pool,
+            threshold,
+            ttl_secs,
+            timeout,
+        })
+    }
+
+    fn conn(&self) -> Result<r2d2::PooledConnection<Client>, String> {
+        let conn = self.pool.get().map_err(|e| e.to_string())?;
+        conn.set_read_timeout(Some(self.timeout)).ok();
+        conn.set_write_timeout(Some(self.timeout)).ok();
+        Ok(conn)
+    }
+
+    /// Return a cached completion whose prompt embedding is within the cosine
+    /// threshold for the same `model`. `None` on a miss or any error.
+    pub fn lookup(&self, embedding: &[f32], model: &str) -> Option<String> {
+        let blob = vector_to_bytes(embedding);
+        let query = format!(
+            "(@model:{{{}}})=>[KNN 1 @vec $BLOB AS dist]",
+            escape_tag_value(model)
+        );
+        let mut conn = self.conn().ok()?;
+        let reply: redis::Value = redis::cmd("FT.SEARCH")
+            .arg(resp_index_name())
+            .arg(&query)
+            .arg("PARAMS")
+            .arg(2)
+            .arg("BLOB")
+            .arg(blob.as_slice())
+            .arg("SORTBY")
+            .arg("dist")
+            .arg("RETURN")
+            .arg(2)
+            .arg("dist")
+            .arg("payload")
+            .arg("DIALECT")
+            .arg(2)
+            .query(&mut *conn)
+            .ok()?;
+        match parse_knn_reply(&reply) {
+            Some((distance, payload)) if cosine_score_from_distance(distance) >= self.threshold => {
+                Some(payload)
+            }
+            _ => None,
+        }
+    }
+
+    /// Store a completion `payload` under the prompt `embedding` + `model`.
+    /// Best-effort: creates the index lazily on first write and drops any error.
+    pub fn insert(&self, embedding: &[f32], model: &str, payload: &str) {
+        let _ = self.try_insert(embedding, model, payload);
+    }
+
+    fn try_insert(&self, embedding: &[f32], model: &str, payload: &str) -> Result<(), String> {
+        let blob = vector_to_bytes(embedding);
+        let key = format!("resp:{}:{}", model, blake3::hash(&blob).to_hex());
+        let mut conn = self.conn()?;
+
+        // Lazily create the index; ignore "Index already exists".
+        let _ = redis::cmd("FT.CREATE")
+            .arg(resp_index_name())
+            .arg("ON")
+            .arg("HASH")
+            .arg("PREFIX")
+            .arg(1)
+            .arg("resp:")
+            .arg("SCHEMA")
+            .arg("model")
+            .arg("TAG")
+            .arg("payload")
+            .arg("TEXT")
+            .arg("vec")
+            .arg("VECTOR")
+            .arg("FLAT")
+            .arg(6)
+            .arg("TYPE")
+            .arg("FLOAT32")
+            .arg("DIM")
+            .arg(embedding.len())
+            .arg("DISTANCE_METRIC")
+            .arg("COSINE")
+            .query::<redis::Value>(&mut *conn);
+
+        redis::cmd("HSET")
+            .arg(&key)
+            .arg("model")
+            .arg(model)
+            .arg("payload")
+            .arg(payload)
+            .arg("vec")
+            .arg(blob.as_slice())
+            .query::<redis::Value>(&mut *conn)
+            .map_err(|e| e.to_string())?;
+
+        redis::cmd("EXPIRE")
+            .arg(&key)
+            .arg(self.ttl_secs)
+            .query::<redis::Value>(&mut *conn)
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+/// Escape a TAG value so RediSearch treats it as one literal token (mirrors the
+/// classification cache).
+fn escape_tag_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            out.push(c);
+        } else {
+            out.push('\\');
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn as_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(bytes) => Some(String::from_utf8_lossy(bytes).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Extract `(distance, payload)` from an `FT.SEARCH ... RETURN 2 dist payload`
+/// reply. `None` for an empty result set or any unexpected shape (fail-open).
+fn parse_knn_reply(value: &redis::Value) -> Option<(f32, String)> {
+    // FT.SEARCH returns: [count, key, [field, val, field, val, ...], ...]
+    if let redis::Value::Array(items) = value {
+        if let Some(redis::Value::Array(fields)) = items.get(2) {
+            let mut dist: Option<f32> = None;
+            let mut payload: Option<String> = None;
+            let mut i = 0;
+            while i + 1 < fields.len() {
+                let name = as_string(&fields[i]);
+                let val = as_string(&fields[i + 1]);
+                match name.as_deref() {
+                    Some("dist") => dist = val.and_then(|s| s.parse::<f32>().ok()),
+                    Some("payload") => payload = val,
+                    _ => {}
+                }
+                i += 2;
+            }
+            if let (Some(d), Some(p)) = (dist, payload) {
+                return Some((d, p));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resp_index_name_is_distinct_from_classification_index() {
+        assert_eq!(resp_index_name(), "resp_semantic_idx");
+        assert_ne!(resp_index_name(), crate::cache::redis_codec::index_name());
+    }
+
+    #[test]
+    fn escape_tag_value_escapes_model_punctuation() {
+        assert_eq!(escape_tag_value("llama"), "llama");
+        assert_eq!(
+            escape_tag_value("llama-32-3b-instruct"),
+            "llama\\-32\\-3b\\-instruct"
+        );
+    }
+
+    fn knn_reply(dist: &str, payload: &str) -> redis::Value {
+        redis::Value::Array(vec![
+            redis::Value::Int(1),
+            redis::Value::BulkString(b"resp:m:abc".to_vec()),
+            redis::Value::Array(vec![
+                redis::Value::BulkString(b"dist".to_vec()),
+                redis::Value::BulkString(dist.as_bytes().to_vec()),
+                redis::Value::BulkString(b"payload".to_vec()),
+                redis::Value::BulkString(payload.as_bytes().to_vec()),
+            ]),
+        ])
+    }
+
+    #[test]
+    fn parse_knn_reply_extracts_distance_and_payload() {
+        let (dist, payload) =
+            parse_knn_reply(&knn_reply("0.03", "{\"choices\":[]}")).expect("must parse");
+        assert!((dist - 0.03).abs() < 1e-6);
+        assert_eq!(payload, "{\"choices\":[]}");
+    }
+
+    #[test]
+    fn parse_knn_reply_is_none_on_empty_result_set() {
+        let value = redis::Value::Array(vec![redis::Value::Int(0)]);
+        assert!(parse_knn_reply(&value).is_none());
+    }
+
+    #[test]
+    fn parse_knn_reply_is_none_on_unexpected_shape() {
+        assert!(parse_knn_reply(&redis::Value::Okay).is_none());
+        assert!(parse_knn_reply(&redis::Value::Nil).is_none());
+    }
+
+    #[test]
+    fn threshold_gates_a_near_miss() {
+        // A distance of 0.2 -> cosine score 0.8; below a 0.92 threshold it must
+        // be rejected, above it accepted. This mirrors the lookup() gate without
+        // needing a live Redis.
+        let score = cosine_score_from_distance(0.2);
+        assert!(score < 0.92);
+        assert!(cosine_score_from_distance(0.05) >= 0.92);
+    }
+}

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -159,8 +159,24 @@ impl std::error::Error for ClassifyError {}
 /// an explicit [`ClassifyError`]. The response is always semantic evidence,
 /// never a final route (AC-010).
 pub trait ClassifierRuntime {
-    /// Classify `input`, returning ranked semantic signals or an explicit error.
-    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError>;
+    /// Embed `input` into its (L2-normalized) vector. This is the expensive
+    /// model-forward stage; it runs at most once per classification so a cache
+    /// lookup never repeats it.
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError>;
+
+    /// Rank a previously-computed `embedding` into typed semantic evidence.
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError>;
+
+    /// Classify `input`: embed once, then rank. Backends inherit this; the
+    /// caching core overrides it to interpose the exact and semantic caches.
+    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
+        let embedding = self.embed(&input)?;
+        self.rank(&embedding, &input)
+    }
 
     /// The immutable identity of what this runtime actually loaded.
     ///
@@ -271,6 +287,22 @@ where
     /// The core adds caching, not identity: it reports the wrapped backend's.
     fn metadata(&self) -> RuntimeMetadata {
         self.runtime.metadata()
+    }
+
+    /// Delegates to the wrapped runtime's `embed`. The core's `classify`
+    /// override does not call this directly (yet) — the L2 semantic-cache
+    /// wiring that interposes here lands in a later task.
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        self.runtime.embed(input)
+    }
+
+    /// Delegates to the wrapped runtime's `rank`.
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        self.runtime.rank(embedding, input)
     }
 
     /// Classify `input` through the shared core: versioned cache -> single-flight
@@ -455,65 +487,6 @@ impl CandleClassifier {
         self.forward_calls.clone()
     }
 
-    /// Real Candle forward (tokenize + embed + rank) with the tokenize and
-    /// forward stages measured independently from their own boundaries (AC-012).
-    /// The runtime counters increment on every real tokenizer call / forward.
-    fn real_forward(&self, text: &str) -> Result<ClassificationResult, ClassifyError> {
-        // Tokenize stage (AC-012): independently measured.
-        let tokenize_start = std::time::Instant::now();
-        self.tokenizer_calls.fetch_add(1, Ordering::SeqCst);
-        let ids = self
-            .embedder
-            .tokenize(text)
-            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
-        self.metrics
-            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
-        // Forward stage (AC-012): the real embed + rank, independently measured.
-        let forward_start = std::time::Instant::now();
-        self.forward_calls.fetch_add(1, Ordering::SeqCst);
-        let embedding = self
-            .embedder
-            .embed_ids(ids)
-            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
-        let (ranked, identity) = match self.taxonomy.as_ref() {
-            Some(t) => (
-                anchor_rank(&embedding, &t.anchors, t.top_k),
-                (
-                    t.classifier_id.clone(),
-                    t.model_revision.clone(),
-                    t.taxonomy_revision.clone(),
-                ),
-            ),
-            None => (
-                cosine_rank(&embedding, &self.prototypes),
-                (
-                    CLASSIFIER_ID.to_string(),
-                    MODEL_REVISION.to_string(),
-                    TAXONOMY_REVISION.to_string(),
-                ),
-            ),
-        };
-        let tokenizer_revision = self
-            .taxonomy
-            .as_ref()
-            .map(|t| t.tokenizer_revision.clone())
-            .unwrap_or_else(|| TOKENIZER_REVISION.to_string());
-        let ranked = ranked
-            .into_iter()
-            .map(|(id, score)| RankedSignal { id, score })
-            .collect();
-        self.metrics
-            .record_stage(LatencyStage::Forward, forward_start.elapsed());
-        Ok(ClassificationResult {
-            classifier_id: identity.0,
-            model_revision: identity.1,
-            tokenizer_revision,
-            taxonomy_revision: identity.2,
-            status: ClassifyStatus::Ok,
-            ranked,
-        })
-    }
-
     /// Build the classifier from the resident ModelCar directory, ranking
     /// against the classifier definition selected by the environment
     /// (`LLM_D_SC_CLASSIFIER`, default `complexity`). The definition may name a
@@ -592,16 +565,79 @@ impl ClassifierRuntime for CandleClassifier {
         }
     }
 
-    /// Classify `input`, returning ranked semantic signals from the ACTUAL
-    /// embedding.
-    ///
-    /// RAW backend forward: tokenize + embed + rank, with the tokenize/forward
-    /// stages measured (AC-012). There is NO cache, single-flight, or hit/miss
-    /// logic here — the generic [`ServiceCore`] that wraps this backend provides
-    /// them, so a cache hit through the core never reaches this forward (AC-006).
-    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
-        let normalized = input.text.trim().to_string();
-        self.real_forward(&normalized)
+    /// Embed `input` with the real Candle tokenizer + model forward, with the
+    /// tokenize and forward stages measured independently from their own
+    /// boundaries (AC-012). The runtime counters increment on every real
+    /// tokenizer call / forward. There is NO cache or single-flight logic
+    /// here — the generic [`ServiceCore`] that wraps this backend provides
+    /// them, so a cache hit through the core never reaches this stage (AC-006).
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        let text = input.text.trim();
+        // Tokenize stage (AC-012): independently measured.
+        let tokenize_start = std::time::Instant::now();
+        self.tokenizer_calls.fetch_add(1, Ordering::SeqCst);
+        let ids = self
+            .embedder
+            .tokenize(text)
+            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
+        // Forward stage (AC-012): the real model forward.
+        let forward_start = std::time::Instant::now();
+        self.forward_calls.fetch_add(1, Ordering::SeqCst);
+        let vector = self
+            .embedder
+            .embed_ids(ids)
+            .map_err(|e| ClassifyError::Embedding(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Forward, forward_start.elapsed());
+        Ok(Embedding::new(vector))
+    }
+
+    /// Rank a previously-computed embedding against the resident taxonomy (or
+    /// the synthetic fallback). No tokenizer/forward counters increment here —
+    /// they belong to the embed stage.
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        let v = &embedding.vector;
+        let (ranked, identity) = match self.taxonomy.as_ref() {
+            Some(t) => (
+                anchor_rank(v, &t.anchors, t.top_k),
+                (
+                    t.classifier_id.clone(),
+                    t.model_revision.clone(),
+                    t.taxonomy_revision.clone(),
+                ),
+            ),
+            None => (
+                cosine_rank(v, &self.prototypes),
+                (
+                    CLASSIFIER_ID.to_string(),
+                    MODEL_REVISION.to_string(),
+                    TAXONOMY_REVISION.to_string(),
+                ),
+            ),
+        };
+        let tokenizer_revision = self
+            .taxonomy
+            .as_ref()
+            .map(|t| t.tokenizer_revision.clone())
+            .unwrap_or_else(|| TOKENIZER_REVISION.to_string());
+        let ranked = ranked
+            .into_iter()
+            .map(|(id, score)| RankedSignal { id, score })
+            .collect();
+        Ok(ClassificationResult {
+            classifier_id: identity.0,
+            model_revision: identity.1,
+            tokenizer_revision,
+            taxonomy_revision: identity.2,
+            status: ClassifyStatus::Ok,
+            ranked,
+        })
     }
 }
 
@@ -706,43 +742,6 @@ impl ClassifyService {
         let prototypes = load_prototypes(root.join("synthetic-prototypes.json"));
         (tokenizer, prototypes)
     }
-
-    /// Deterministic tokenize + rank: tokenize with the resident tokenizer,
-    /// build a deterministic pseudo-embedding from the token IDs, and cosine-rank
-    /// against the synthetic prototypes. No model forward. A tokenization
-    /// failure is an explicit [`ClassifyError::Tokenizer`] — never a fabricated
-    /// label (spec failure contract).
-    fn deterministic_classify(&self, context: &str) -> Result<ClassificationResult, ClassifyError> {
-        // Tokenize stage (AC-012): independently measured.
-        let tokenize_start = std::time::Instant::now();
-        let ids = self
-            .tokenizer
-            .tokenize(context)
-            .map_err(|e| ClassifyError::Tokenizer(e.to_string()))?;
-        self.metrics
-            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
-        // Forward stage (AC-012): the deterministic embed + rank, independently
-        // measured from the tokenize boundary.
-        let forward_start = std::time::Instant::now();
-        let mut embedding = vec![0.0f32; SYNTHETIC_DIM];
-        for id in ids {
-            embedding[(id as usize) % SYNTHETIC_DIM] += 1.0;
-        }
-        let ranked = cosine_rank(&embedding, &self.prototypes)
-            .into_iter()
-            .map(|(id, score)| RankedSignal { id, score })
-            .collect();
-        self.metrics
-            .record_stage(LatencyStage::Forward, forward_start.elapsed());
-        Ok(ClassificationResult {
-            classifier_id: CLASSIFIER_ID.to_string(),
-            model_revision: MODEL_REVISION.to_string(),
-            tokenizer_revision: TOKENIZER_REVISION.to_string(),
-            taxonomy_revision: TAXONOMY_REVISION.to_string(),
-            status: ClassifyStatus::Ok,
-            ranked,
-        })
-    }
 }
 
 impl ClassifierRuntime for ClassifyService {
@@ -757,16 +756,55 @@ impl ClassifierRuntime for ClassifyService {
         }
     }
 
-    /// Classify `input`, returning ranked semantic signals.
-    ///
-    /// RAW backend forward: deterministic tokenize + rank over the synthetic
-    /// prototypes, with the tokenize/forward stages measured (AC-012). There is
-    /// NO cache, single-flight, or hit/miss logic here — the generic
-    /// [`ServiceCore`] that wraps this backend provides them, so a cache hit
-    /// through the core never reaches this forward (AC-006).
-    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
-        let normalized = input.text.trim().to_string();
-        self.deterministic_classify(&normalized)
+    /// Embed `input`: tokenize with the resident tokenizer and build a
+    /// deterministic pseudo-embedding from the token IDs. No model forward. A
+    /// tokenization failure is an explicit [`ClassifyError::Tokenizer`] — never
+    /// a fabricated label (spec failure contract). There is NO cache or
+    /// single-flight logic here — the generic [`ServiceCore`] that wraps this
+    /// backend provides them, so a cache hit through the core never reaches
+    /// this stage (AC-006).
+    fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        let context = input.text.trim();
+        // Tokenize stage (AC-012): independently measured.
+        let tokenize_start = std::time::Instant::now();
+        let ids = self
+            .tokenizer
+            .tokenize(context)
+            .map_err(|e| ClassifyError::Tokenizer(e.to_string()))?;
+        self.metrics
+            .record_stage(LatencyStage::Tokenize, tokenize_start.elapsed());
+        let mut vector = vec![0.0f32; SYNTHETIC_DIM];
+        for id in ids {
+            vector[(id as usize) % SYNTHETIC_DIM] += 1.0;
+        }
+        Ok(Embedding::new(vector))
+    }
+
+    /// Rank a previously-computed embedding by cosine similarity against the
+    /// synthetic prototypes. No tokenizer counters here — they belong to the
+    /// embed stage.
+    fn rank(
+        &self,
+        embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        // Forward stage (AC-012): the deterministic rank, independently
+        // measured from the tokenize boundary.
+        let forward_start = std::time::Instant::now();
+        let ranked = cosine_rank(&embedding.vector, &self.prototypes)
+            .into_iter()
+            .map(|(id, score)| RankedSignal { id, score })
+            .collect();
+        self.metrics
+            .record_stage(LatencyStage::Forward, forward_start.elapsed());
+        Ok(ClassificationResult {
+            classifier_id: CLASSIFIER_ID.to_string(),
+            model_revision: MODEL_REVISION.to_string(),
+            tokenizer_revision: TOKENIZER_REVISION.to_string(),
+            taxonomy_revision: TAXONOMY_REVISION.to_string(),
+            status: ClassifyStatus::Ok,
+            ranked,
+        })
     }
 }
 
@@ -996,5 +1034,28 @@ mod tests {
         let e = Embedding::new(vec![0.0, 1.0, 0.0]);
         assert_eq!(e.dim(), 3);
         assert_eq!(e.vector, vec![0.0, 1.0, 0.0]);
+    }
+
+    /// The `embed`/`rank` split must reproduce the provided `classify` default
+    /// exactly on the synthetic path, and `embed` must be independently callable
+    /// (a later cache tier interposes here).
+    #[test]
+    fn embed_then_rank_matches_classify_on_synthetic() {
+        let svc = ClassifyService::from_synthetic_fixtures();
+        let input = ClassificationInput {
+            text: "this is a golden sensitivity input".to_string(),
+            requested_signals: vec!["sensitivity".to_string()],
+            session_metadata: HashMap::new(),
+        };
+        // Two-stage path.
+        let embedding = svc.embed(&input).expect("embed");
+        assert_eq!(embedding.dim(), SYNTHETIC_DIM);
+        let staged = svc.rank(&embedding, &input).expect("rank");
+        // Provided classify() default must produce the identical result.
+        let one_shot = svc.classify(input).expect("classify");
+        assert_eq!(
+            staged, one_shot,
+            "embed+rank must equal the provided classify"
+        );
     }
 }

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -62,6 +62,26 @@ pub struct ClassificationInput {
     pub session_metadata: HashMap<String, String>,
 }
 
+/// A classifier-produced embedding: the L2-normalized vector the ranker and the
+/// semantic cache both consume. Produced exactly once per classification so the
+/// (expensive) model forward is never repeated for a cache lookup.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Embedding {
+    pub vector: Vec<f32>,
+}
+
+impl Embedding {
+    /// Wrap a raw embedding vector.
+    pub fn new(vector: Vec<f32>) -> Self {
+        Embedding { vector }
+    }
+
+    /// The embedding dimension.
+    pub fn dim(&self) -> usize {
+        self.vector.len()
+    }
+}
+
 /// One ranked semantic signal: an id and its deterministic similarity score.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RankedSignal {
@@ -969,5 +989,12 @@ mod tests {
             Err(other) => panic!("must be an actionable unavailable error, got {other:?}"),
         }
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn embedding_reports_its_dimension() {
+        let e = Embedding::new(vec![0.0, 1.0, 0.0]);
+        assert_eq!(e.dim(), 3);
+        assert_eq!(e.vector, vec![0.0, 1.0, 0.0]);
     }
 }

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -83,7 +83,7 @@ impl Embedding {
 }
 
 /// One ranked semantic signal: an id and its deterministic similarity score.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RankedSignal {
     pub id: String,
     pub score: f64,
@@ -95,7 +95,7 @@ pub struct RankedSignal {
 /// (model/tokenizer/taxonomy) that reproduce the result, the ranked signals,
 /// and a [`ClassifyStatus`]. It NEVER contains a route/endpoint field — routing
 /// authority is the AI Gateway (AC-010).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ClassificationResult {
     pub classifier_id: String,
     pub model_revision: String,
@@ -110,7 +110,7 @@ pub struct ClassificationResult {
 /// `Ok` is a real ranked result; `Abstain` is "insufficient context where
 /// required — do not fabricate a label"; `Error` is an explicit failure (the
 /// typed error detail travels via [`ClassifyError`] on the `Result`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ClassifyStatus {
     Ok,
     Abstain,

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::cache::{CacheKey, SharedCache};
+use crate::cache::{identity_tag, CacheKey, NoopSemanticCache, SemanticCache, SharedCache};
 use crate::metrics::{LatencyStage, Metrics};
 use crate::ranker::{anchor_rank, cosine_rank, AnchorSet, Prototype};
 use crate::taxonomy::ClassifierDefinition;
@@ -242,6 +242,7 @@ impl RuntimeMetadata {
 pub struct ServiceCore<R> {
     runtime: Arc<R>,
     cache: SharedCache,
+    semantic: Arc<dyn SemanticCache>,
     metrics: Metrics,
 }
 
@@ -256,11 +257,29 @@ where
 
     /// Build a service core whose cache and hit/miss/total/queue metrics record
     /// into the CALLER-SUPPLIED [`Metrics`] handle, so the backend's own
-    /// tokenize/forward stage recording can share the same registry.
+    /// tokenize/forward stage recording can share the same registry. The L2
+    /// semantic cache tier defaults to [`NoopSemanticCache`] (always misses),
+    /// so behaviour is UNCHANGED unless a semantic cache is opted into via
+    /// [`ServiceCore::with_semantic_cache`].
     pub fn with_metrics(runtime: R, metrics: Metrics) -> Self {
         ServiceCore {
             runtime: Arc::new(runtime),
             cache: SharedCache::new(),
+            semantic: Arc::new(NoopSemanticCache),
+            metrics,
+        }
+    }
+
+    /// Build a service core with an explicit L2 semantic cache tier.
+    pub fn with_semantic_cache(
+        runtime: R,
+        metrics: Metrics,
+        semantic: Arc<dyn SemanticCache>,
+    ) -> Self {
+        ServiceCore {
+            runtime: Arc::new(runtime),
+            cache: SharedCache::new(),
+            semantic,
             metrics,
         }
     }
@@ -289,9 +308,7 @@ where
         self.runtime.metadata()
     }
 
-    /// Delegates to the wrapped runtime's `embed`. The core's `classify`
-    /// override does not call this directly (yet) — the L2 semantic-cache
-    /// wiring that interposes here lands in a later task.
+    /// Delegates to the wrapped runtime's `embed`.
     fn embed(&self, input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
         self.runtime.embed(input)
     }
@@ -328,6 +345,9 @@ where
             taxonomy_rev,
             &normalized,
         );
+        // The L2 isolation tag is built from the SAME identity fields as the L1
+        // blake3 key, so a revision bump can never serve a stale semantic label.
+        let tag = identity_tag(meta.cache_identity());
         let metrics = self.metrics.clone();
         // A miss runs the raw backend forward on the designated single-flight
         // caller; a hit bypasses it entirely (AC-006). The flag distinguishes the
@@ -335,8 +355,10 @@ where
         let forward_ran = Arc::new(AtomicBool::new(false));
         let forward = {
             let runtime = self.runtime.clone();
+            let semantic = self.semantic.clone();
             let metrics = metrics.clone();
             let forward_ran = forward_ran.clone();
+            let tag = tag.clone();
             let input = ClassificationInput {
                 text: normalized,
                 requested_signals: input.requested_signals,
@@ -345,7 +367,16 @@ where
             move || {
                 forward_ran.store(true, Ordering::SeqCst);
                 let _ = &metrics;
-                runtime.classify(input)
+                // Embed once. Reused by both the L2 lookup and the ranker.
+                let embedding = runtime.embed(&input)?;
+                // L2 semantic lookup (fail-open: None on any trouble).
+                if let Some(hit) = semantic.lookup(&embedding, &tag) {
+                    return Ok(hit);
+                }
+                // L2 miss: rank, then best-effort write-back.
+                let result = runtime.rank(&embedding, &input)?;
+                semantic.insert(&embedding, &result, &tag);
+                Ok(result)
             }
         };
         let result = self.cache.classify_concurrent(key, forward);
@@ -1034,6 +1065,88 @@ mod tests {
         let e = Embedding::new(vec![0.0, 1.0, 0.0]);
         assert_eq!(e.dim(), 3);
         assert_eq!(e.vector, vec![0.0, 1.0, 0.0]);
+    }
+
+    /// A spy [`crate::cache::SemanticCache`] proves an L1 miss consults the L2
+    /// tier exactly once, and an L2 hit is served verbatim WITHOUT invoking the
+    /// ranker.
+    #[test]
+    fn service_core_serves_semantic_hit_without_ranking() {
+        use crate::cache::SemanticCache;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc as StdArc;
+
+        struct SpyCache {
+            canned: ClassificationResult,
+            lookups: StdArc<AtomicUsize>,
+        }
+        impl SemanticCache for SpyCache {
+            fn lookup(&self, _e: &Embedding, _id: &str) -> Option<ClassificationResult> {
+                self.lookups.fetch_add(1, Ordering::SeqCst);
+                Some(self.canned.clone())
+            }
+            fn insert(&self, _e: &Embedding, _r: &ClassificationResult, _id: &str) {}
+        }
+
+        let canned = ClassificationResult {
+            classifier_id: "spy".into(),
+            model_revision: "m".into(),
+            tokenizer_revision: "t".into(),
+            taxonomy_revision: "x".into(),
+            status: ClassifyStatus::Ok,
+            ranked: vec![RankedSignal {
+                id: "SEMANTIC_HIT".into(),
+                score: 0.99,
+            }],
+        };
+        let lookups = StdArc::new(AtomicUsize::new(0));
+        let spy = StdArc::new(SpyCache {
+            canned: canned.clone(),
+            lookups: lookups.clone(),
+        });
+
+        let core = ServiceCore::with_semantic_cache(
+            ClassifyService::from_synthetic_fixtures(),
+            Metrics::new(),
+            spy,
+        );
+        let input = ClassificationInput {
+            text: "some novel prompt not seen before".to_string(),
+            requested_signals: vec!["sensitivity".to_string()],
+            session_metadata: HashMap::new(),
+        };
+        let out = core.classify(input).expect("classify");
+        assert_eq!(
+            lookups.load(Ordering::SeqCst),
+            1,
+            "L1 miss must consult L2 once"
+        );
+        assert_eq!(
+            out.ranked[0].id, "SEMANTIC_HIT",
+            "L2 hit must be served verbatim"
+        );
+    }
+
+    /// The default [`ServiceCore`] (Noop L2) must remain unaffected: an L1 miss
+    /// with a Noop L2 always misses, so it must run exactly one embed and one
+    /// rank, reproducing the pre-L2 behaviour byte-for-byte.
+    #[test]
+    fn service_core_noop_default_is_unaffected() {
+        let core =
+            ServiceCore::with_metrics(ClassifyService::from_synthetic_fixtures(), Metrics::new());
+        let input = ClassificationInput {
+            text: "this is a golden sensitivity input".to_string(),
+            requested_signals: vec!["sensitivity".to_string()],
+            session_metadata: HashMap::new(),
+        };
+        let via_core = core.classify(input.clone()).expect("core classify");
+        let direct = ClassifyService::from_synthetic_fixtures()
+            .classify(input)
+            .expect("direct classify");
+        assert_eq!(
+            via_core, direct,
+            "default Noop L2 must not change the classification result"
+        );
     }
 
     /// The `embed`/`rank` split must reproduce the provided `classify` default

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,9 @@ use std::collections::HashSet;
 /// Runtime backends this crate can currently host.
 pub const KNOWN_BACKENDS: &[&str] = &["candle"];
 
+/// Cache strategies this crate can host.
+pub const KNOWN_CACHE_STRATEGIES: &[&str] = &["exact", "redis-semantic"];
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -31,13 +34,77 @@ pub struct ClassifierConfig {
     pub model_path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// Note: `Eq` is intentionally not derived here (unlike other simple error
+// enums in this crate) because `InvalidThreshold` carries an `f32`, which
+// has no `Eq` impl (NaN != NaN). `PartialEq` is sufficient for the
+// `assert_eq!`/`match` usages in this crate's tests.
+#[derive(Debug, Clone, PartialEq)]
 pub enum ConfigError {
     MissingClassifiers,
     UnknownBackend(String),
     DuplicateClassifierId(String),
     InvalidModelPath(String),
     Parse(String),
+    UnknownCacheStrategy(String),
+    MissingRedisUrl,
+    InvalidThreshold(f32),
+}
+
+/// L2 semantic-cache configuration, resolved from the environment.
+///
+/// Off by default: the default strategy is `"exact"`, which corresponds to
+/// the existing L1-only, single-flight exact-match cache. Selecting
+/// `"redis-semantic"` requires `LLM_D_SC_REDIS_URL`; this type only
+/// validates that surface, it does not construct a Redis client.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheConfig {
+    pub strategy: String,
+    pub redis_url: Option<String>,
+    pub threshold: f32,
+    pub ttl_secs: u64,
+    pub timeout_ms: u64,
+}
+
+impl CacheConfig {
+    /// Resolve from process environment variables.
+    pub fn from_env() -> Result<CacheConfig, ConfigError> {
+        Self::from_env_with(|k| std::env::var(k).ok())
+    }
+
+    /// Resolve from an arbitrary getter (injected for tests).
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Result<CacheConfig, ConfigError> {
+        let strategy = get("LLM_D_SC_CACHE").unwrap_or_else(|| "exact".to_string());
+        if !KNOWN_CACHE_STRATEGIES.contains(&strategy.as_str()) {
+            return Err(ConfigError::UnknownCacheStrategy(strategy));
+        }
+        let redis_url = get("LLM_D_SC_REDIS_URL").filter(|s| !s.trim().is_empty());
+        if strategy == "redis-semantic" && redis_url.is_none() {
+            return Err(ConfigError::MissingRedisUrl);
+        }
+        let threshold = get("LLM_D_SC_CACHE_THRESHOLD")
+            .map(|s| {
+                s.parse::<f32>()
+                    .map_err(|_| ConfigError::InvalidThreshold(f32::NAN))
+            })
+            .transpose()?
+            .unwrap_or(0.90);
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(ConfigError::InvalidThreshold(threshold));
+        }
+        let ttl_secs = get("LLM_D_SC_CACHE_TTL")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(86_400);
+        let timeout_ms = get("LLM_D_SC_CACHE_TIMEOUT_MS")
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(50);
+        Ok(CacheConfig {
+            strategy,
+            redis_url,
+            threshold,
+            ttl_secs,
+            timeout_ms,
+        })
+    }
 }
 
 impl Default for ServerConfig {
@@ -167,6 +234,93 @@ mod tests {
         match Config::parse(toml) {
             Err(ConfigError::InvalidModelPath(id)) => assert_eq!(id, "sensitivity"),
             other => panic!("expected InvalidModelPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_config_defaults_to_exact() {
+        let cfg = CacheConfig::from_env_with(|_| None).expect("defaults");
+        assert_eq!(cfg.strategy, "exact");
+        assert!(cfg.redis_url.is_none());
+        assert!((cfg.threshold - 0.90).abs() < 1e-6);
+        assert_eq!(cfg.ttl_secs, 86_400);
+        assert_eq!(cfg.timeout_ms, 50);
+    }
+
+    #[test]
+    fn redis_semantic_requires_url() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("redis-semantic".to_string()),
+            _ => None,
+        };
+        match CacheConfig::from_env_with(get) {
+            Err(ConfigError::MissingRedisUrl) => {}
+            other => panic!("expected MissingRedisUrl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn redis_semantic_with_url_parses() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("redis-semantic".to_string()),
+            "LLM_D_SC_REDIS_URL" => Some("redis://localhost:6379".to_string()),
+            _ => None,
+        };
+        let cfg = CacheConfig::from_env_with(get).expect("valid redis-semantic config");
+        assert_eq!(cfg.strategy, "redis-semantic");
+        assert_eq!(cfg.redis_url.as_deref(), Some("redis://localhost:6379"));
+    }
+
+    #[test]
+    fn unknown_cache_strategy_rejected() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("memcached".to_string()),
+            _ => None,
+        };
+        match CacheConfig::from_env_with(get) {
+            Err(ConfigError::UnknownCacheStrategy(s)) => assert_eq!(s, "memcached"),
+            other => panic!("expected UnknownCacheStrategy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn threshold_out_of_range_rejected() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("exact".to_string()),
+            "LLM_D_SC_CACHE_THRESHOLD" => Some("1.5".to_string()),
+            _ => None,
+        };
+        match CacheConfig::from_env_with(get) {
+            Err(ConfigError::InvalidThreshold(v)) => assert!((v - 1.5).abs() < 1e-6),
+            other => panic!("expected InvalidThreshold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn threshold_ttl_timeout_overrides_parse() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("exact".to_string()),
+            "LLM_D_SC_CACHE_THRESHOLD" => Some("0.75".to_string()),
+            "LLM_D_SC_CACHE_TTL" => Some("120".to_string()),
+            "LLM_D_SC_CACHE_TIMEOUT_MS" => Some("25".to_string()),
+            _ => None,
+        };
+        let cfg = CacheConfig::from_env_with(get).expect("valid overrides");
+        assert!((cfg.threshold - 0.75).abs() < 1e-6);
+        assert_eq!(cfg.ttl_secs, 120);
+        assert_eq!(cfg.timeout_ms, 25);
+    }
+
+    #[test]
+    fn non_numeric_threshold_rejected() {
+        let get = |k: &str| match k {
+            "LLM_D_SC_CACHE" => Some("exact".to_string()),
+            "LLM_D_SC_CACHE_THRESHOLD" => Some("not-a-number".to_string()),
+            _ => None,
+        };
+        match CacheConfig::from_env_with(get) {
+            Err(ConfigError::InvalidThreshold(v)) => assert!(v.is_nan()),
+            other => panic!("expected InvalidThreshold, got {other:?}"),
         }
     }
 }

--- a/src/grpc/classify.rs
+++ b/src/grpc/classify.rs
@@ -354,20 +354,35 @@ impl ClassifyServer {
         let semantic: Arc<dyn crate::cache::SemanticCache> = if cache_cfg.strategy
             == "redis-semantic"
         {
-            match crate::cache::redis::RedisSemanticCache::connect(&cache_cfg, metrics.clone()) {
-                Ok(rc) => {
-                    eprintln!(
-                        "llm-d-sc: semantic cache enabled (redis-semantic, threshold {})",
-                        cache_cfg.threshold
-                    );
-                    Arc::new(rc)
+            #[cfg(feature = "redis-semantic")]
+            {
+                match crate::cache::redis::RedisSemanticCache::connect(&cache_cfg, metrics.clone())
+                {
+                    Ok(rc) => {
+                        eprintln!(
+                            "llm-d-sc: semantic cache enabled (redis-semantic, threshold {})",
+                            cache_cfg.threshold
+                        );
+                        Arc::new(rc)
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "llm-d-sc: redis-semantic unavailable ({e}); falling back to exact cache"
+                        );
+                        Arc::new(crate::cache::NoopSemanticCache)
+                    }
                 }
-                Err(e) => {
-                    eprintln!(
-                        "llm-d-sc: redis-semantic unavailable ({e}); falling back to exact cache"
-                    );
-                    Arc::new(crate::cache::NoopSemanticCache)
-                }
+            }
+            // Built without the `redis-semantic` feature: the strategy was
+            // requested but the backend is not compiled in. Fail open to the
+            // exact-only cache rather than refusing to start.
+            #[cfg(not(feature = "redis-semantic"))]
+            {
+                eprintln!(
+                    "llm-d-sc: LLM_D_SC_CACHE=redis-semantic requested but this binary was \
+                     built without the `redis-semantic` feature; falling back to exact cache"
+                );
+                Arc::new(crate::cache::NoopSemanticCache)
             }
         } else {
             Arc::new(crate::cache::NoopSemanticCache)

--- a/src/grpc/classify.rs
+++ b/src/grpc/classify.rs
@@ -128,6 +128,27 @@ where
         }
     }
 
+    /// Like [`ClassifyServiceImpl::with_executor`] but wraps the backend in a
+    /// [`crate::classify::ServiceCore`] carrying an explicit L2 semantic cache
+    /// tier (production opt-in). The synthetic/test paths keep using
+    /// `with_executor` (Noop L2).
+    pub fn with_executor_and_cache(
+        service: R,
+        telemetry: Telemetry,
+        metrics: Metrics,
+        bound: usize,
+        semantic: Arc<dyn crate::cache::SemanticCache>,
+    ) -> Self {
+        let core =
+            crate::classify::ServiceCore::with_semantic_cache(service, metrics.clone(), semantic);
+        let executor = InferenceExecutor::spawn(core, metrics.clone(), bound);
+        Self {
+            telemetry,
+            metrics,
+            executor: Arc::new(executor),
+        }
+    }
+
     /// The configured bound on total admitted (in-flight + queued) work.
     pub fn queue_bound(&self) -> usize {
         self.executor.bound()
@@ -316,11 +337,47 @@ impl ClassifyServer {
         // real Candle forward are visible to a benchmark harness (AC-012).
         let metrics = classifier.metrics();
         let telemetry = Telemetry::new();
-        let service = ClassifyServiceImpl::with_executor(
+        // Select the L2 cache strategy from the environment (off by default:
+        // `LLM_D_SC_CACHE` unset resolves to "exact", i.e. Noop). Any
+        // misconfiguration or a Redis that cannot be reached falls back to
+        // the exact-only cache rather than failing to start (fail-open).
+        let cache_cfg = crate::config::CacheConfig::from_env().unwrap_or_else(|e| {
+            eprintln!("llm-d-sc: invalid cache config ({e:?}); falling back to exact cache");
+            crate::config::CacheConfig {
+                strategy: "exact".into(),
+                redis_url: None,
+                threshold: 0.90,
+                ttl_secs: 86_400,
+                timeout_ms: 50,
+            }
+        });
+        let semantic: Arc<dyn crate::cache::SemanticCache> = if cache_cfg.strategy
+            == "redis-semantic"
+        {
+            match crate::cache::redis::RedisSemanticCache::connect(&cache_cfg, metrics.clone()) {
+                Ok(rc) => {
+                    eprintln!(
+                        "llm-d-sc: semantic cache enabled (redis-semantic, threshold {})",
+                        cache_cfg.threshold
+                    );
+                    Arc::new(rc)
+                }
+                Err(e) => {
+                    eprintln!(
+                        "llm-d-sc: redis-semantic unavailable ({e}); falling back to exact cache"
+                    );
+                    Arc::new(crate::cache::NoopSemanticCache)
+                }
+            }
+        } else {
+            Arc::new(crate::cache::NoopSemanticCache)
+        };
+        let service = ClassifyServiceImpl::with_executor_and_cache(
             classifier,
             telemetry.clone(),
             metrics.clone(),
             DEFAULT_QUEUE_BOUND,
+            semantic,
         );
         Self::serve(
             addr,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -139,6 +139,12 @@ pub struct MetricsSnapshot {
     pub cache_hits: u64,
     /// Number of classification requests that ran a real forward (cache miss).
     pub cache_misses: u64,
+    /// Number of L2 cache hits.
+    pub l2_hits: u64,
+    /// Number of L2 cache misses.
+    pub l2_misses: u64,
+    /// Number of L2 degraded responses.
+    pub l2_degraded: u64,
 }
 
 /// The shared latency/counter registry behind the metrics surface.
@@ -159,6 +165,9 @@ struct Inner {
     total: Duration,
     cache_hits: u64,
     cache_misses: u64,
+    l2_hits: u64,
+    l2_misses: u64,
+    l2_degraded: u64,
     hist_queue: Histogram,
     hist_tokenize: Histogram,
     hist_forward: Histogram,
@@ -218,6 +227,21 @@ impl Metrics {
         self.inner.lock().unwrap().cache_misses += 1;
     }
 
+    /// Record one L2 cache hit.
+    pub fn record_l2_hit(&self) {
+        self.inner.lock().unwrap().l2_hits += 1;
+    }
+
+    /// Record one L2 cache miss.
+    pub fn record_l2_miss(&self) {
+        self.inner.lock().unwrap().l2_misses += 1;
+    }
+
+    /// Record one L2 degraded response.
+    pub fn record_l2_degraded(&self) {
+        self.inner.lock().unwrap().l2_degraded += 1;
+    }
+
     /// An immutable snapshot of the accumulated latency decomposition.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let inner = self.inner.lock().unwrap();
@@ -228,6 +252,9 @@ impl Metrics {
             total: inner.total,
             cache_hits: inner.cache_hits,
             cache_misses: inner.cache_misses,
+            l2_hits: inner.l2_hits,
+            l2_misses: inner.l2_misses,
+            l2_degraded: inner.l2_degraded,
         }
     }
 }
@@ -376,5 +403,19 @@ mod tests {
         assert_eq!(snap.cache_hits, 2);
         assert_eq!(snap.cache_misses, 1);
         assert_eq!(snap.cache_hits + snap.cache_misses, 3);
+    }
+
+    /// L2 counters increment independently.
+    #[test]
+    fn l2_counters_increment_independently() {
+        let m = Metrics::new();
+        m.record_l2_hit();
+        m.record_l2_hit();
+        m.record_l2_miss();
+        m.record_l2_degraded();
+        let s = m.snapshot();
+        assert_eq!(s.l2_hits, 2);
+        assert_eq!(s.l2_misses, 1);
+        assert_eq!(s.l2_degraded, 1);
     }
 }

--- a/tests/executor_pool.rs
+++ b/tests/executor_pool.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 use llm_d_sc::classify::{
     ClassificationInput, ClassificationResult, ClassifierRuntime, ClassifyError, ClassifyStatus,
-    RankedSignal, RuntimeMetadata,
+    Embedding, RankedSignal, RuntimeMetadata,
 };
 use llm_d_sc::handoff::InferenceExecutor;
 use llm_d_sc::metrics::Metrics;
@@ -43,6 +43,20 @@ impl ClassifierRuntime for SlowClassifier {
             taxonomy_revision: "test".into(),
             artifact_digest: None,
         }
+    }
+
+    // This test double overrides `classify` directly to control the forward
+    // delay and concurrency bookkeeping; `embed`/`rank` are never reached.
+    fn embed(&self, _input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        unimplemented!("SlowClassifier overrides classify directly")
+    }
+
+    fn rank(
+        &self,
+        _embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        unimplemented!("SlowClassifier overrides classify directly")
     }
 
     fn classify(&self, _input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use llm_d_sc::classify::{
     ClassificationInput, ClassificationResult, ClassifierRuntime, ClassifyError, ClassifyStatus,
-    RankedSignal, RuntimeMetadata,
+    Embedding, RankedSignal, RuntimeMetadata,
 };
 use llm_d_sc::grpc::classify::generated;
 use llm_d_sc::grpc::classify::ClassifyServiceImpl;
@@ -50,6 +50,20 @@ impl ClassifierRuntime for SlowClassifier {
             taxonomy_revision: "test".into(),
             artifact_digest: None,
         }
+    }
+
+    // This test double overrides `classify` directly to control the forward
+    // delay; `embed`/`rank` are never reached.
+    fn embed(&self, _input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
+        unimplemented!("SlowClassifier overrides classify directly")
+    }
+
+    fn rank(
+        &self,
+        _embedding: &Embedding,
+        _input: &ClassificationInput,
+    ) -> Result<ClassificationResult, ClassifyError> {
+        unimplemented!("SlowClassifier overrides classify directly")
     }
 
     fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -52,10 +52,13 @@ impl ClassifierRuntime for SlowClassifier {
         }
     }
 
-    // This test double overrides `classify` directly to control the forward
-    // delay; `embed`/`rank` are never reached.
+    // The slow model forward runs in `embed` — on the dedicated inference
+    // executor thread — so admitted work stays in-flight and the bounded queue
+    // saturates. `ServiceCore` drives the runtime as `embed` then `rank`, so the
+    // delay must live here rather than in `classify`.
     fn embed(&self, _input: &ClassificationInput) -> Result<Embedding, ClassifyError> {
-        unimplemented!("SlowClassifier overrides classify directly")
+        std::thread::sleep(self.forward_delay);
+        Ok(Embedding::new(vec![0.0]))
     }
 
     fn rank(
@@ -63,12 +66,6 @@ impl ClassifierRuntime for SlowClassifier {
         _embedding: &Embedding,
         _input: &ClassificationInput,
     ) -> Result<ClassificationResult, ClassifyError> {
-        unimplemented!("SlowClassifier overrides classify directly")
-    }
-
-    fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
-        std::thread::sleep(self.forward_delay);
-        let _ = input;
         Ok(ClassificationResult {
             classifier_id: "slow-classifier".to_string(),
             model_revision: "slow-model".to_string(),

--- a/tests/redis_semantic.rs
+++ b/tests/redis_semantic.rs
@@ -1,0 +1,111 @@
+//! Integration tests for [`llm_d_sc::cache::redis::RedisSemanticCache`].
+//!
+//! The fail-open test runs WITHOUT any Redis server (points at a dead
+//! address) and must always pass under plain `cargo test`. The two
+//! live-Redis tests are `#[ignore]`d (repo convention for external
+//! resources) and require a running Redis Stack at `REDIS_URL`
+//! (see hack/redis-stack.sh).
+
+use llm_d_sc::cache::redis::RedisSemanticCache;
+use llm_d_sc::cache::SemanticCache;
+use llm_d_sc::classify::{ClassificationResult, ClassifyStatus, Embedding, RankedSignal};
+use llm_d_sc::config::CacheConfig;
+use llm_d_sc::metrics::Metrics;
+
+fn cfg(url: &str) -> CacheConfig {
+    CacheConfig {
+        strategy: "redis-semantic".into(),
+        redis_url: Some(url.into()),
+        threshold: 0.90,
+        ttl_secs: 3600,
+        timeout_ms: 50,
+    }
+}
+
+fn result(id: &str) -> ClassificationResult {
+    ClassificationResult {
+        classifier_id: "complexity".into(),
+        model_revision: "m".into(),
+        tokenizer_revision: "t".into(),
+        taxonomy_revision: "x".into(),
+        status: ClassifyStatus::Ok,
+        ranked: vec![RankedSignal {
+            id: id.into(),
+            score: 0.9,
+        }],
+    }
+}
+
+#[test]
+fn lookup_is_fail_open_when_redis_is_unreachable() {
+    // Port 1 is never a Redis; connect may succeed lazily, but lookup must
+    // never panic or error — it returns None (fail-open to compute).
+    let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), Metrics::new());
+    if let Ok(cache) = cache {
+        let e = Embedding::new(vec![0.1, 0.2, 0.3]);
+        assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
+        // insert must not panic either.
+        cache.insert(&e, &result("SIMPLE"), "complexity|m|t|x");
+    }
+}
+
+#[test]
+fn breaker_open_short_circuits_without_calling_redis() {
+    // Every lookup that actually reaches (and fails against) Redis records a
+    // degraded outcome. Once the breaker opens, further lookups must still
+    // fail open (None) but must NOT record another degraded outcome — that
+    // is the observable proof that the open breaker short-circuited BEFORE
+    // attempting Redis, rather than trying and failing again.
+    let metrics = Metrics::new();
+    let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), metrics.clone())
+        .expect("connect (lazy) must succeed even though the address is dead");
+    let e = Embedding::new(vec![0.1, 0.2, 0.3]);
+
+    // Drive the breaker open (failure_threshold is 5, see RedisSemanticCache::connect).
+    for _ in 0..5 {
+        assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
+    }
+    let degraded_at_open = metrics.snapshot().l2_degraded;
+    assert!(
+        degraded_at_open >= 5,
+        "each failed Redis attempt before the breaker opens must record a degraded outcome"
+    );
+
+    // Once open, further lookups must short-circuit: still None, but the
+    // degraded counter must stop moving because Redis is never contacted.
+    for _ in 0..5 {
+        assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
+    }
+    assert_eq!(
+        metrics.snapshot().l2_degraded,
+        degraded_at_open,
+        "an open breaker must short-circuit without attempting Redis (no new degraded records)"
+    );
+}
+
+#[test]
+#[ignore] // requires a running Redis Stack at REDIS_URL (see hack/redis-stack.sh)
+fn paraphrase_hit_after_insert() {
+    let url = std::env::var("REDIS_URL").expect("REDIS_URL for the live test");
+    let cache = RedisSemanticCache::connect(&cfg(&url), Metrics::new()).expect("connect");
+    let a = Embedding::new(vec![1.0, 0.0, 0.0]);
+    let close = Embedding::new(vec![0.98, 0.02, 0.0]); // near-identical direction
+    cache.insert(&a, &result("SIMPLE"), "complexity|m|t|x");
+    std::thread::sleep(std::time::Duration::from_millis(100)); // async write-back settles
+    let hit = cache.lookup(&close, "complexity|m|t|x");
+    assert_eq!(hit.map(|r| r.ranked[0].id.clone()), Some("SIMPLE".into()));
+}
+
+#[test]
+#[ignore] // requires a running Redis Stack at REDIS_URL
+fn identity_isolates_across_revisions() {
+    let url = std::env::var("REDIS_URL").expect("REDIS_URL for the live test");
+    let cache = RedisSemanticCache::connect(&cfg(&url), Metrics::new()).expect("connect");
+    let e = Embedding::new(vec![0.0, 1.0, 0.0]);
+    cache.insert(&e, &result("SIMPLE"), "complexity|m1|t|x");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(
+        cache.lookup(&e, "complexity|m2|t|x").is_none(),
+        "different revision must not hit"
+    );
+}

--- a/tests/redis_semantic.rs
+++ b/tests/redis_semantic.rs
@@ -51,35 +51,48 @@ fn lookup_is_fail_open_when_redis_is_unreachable() {
 
 #[test]
 fn breaker_open_short_circuits_without_calling_redis() {
-    // Every lookup that actually reaches (and fails against) Redis records a
-    // degraded outcome. Once the breaker opens, further lookups must still
-    // fail open (None) but must NOT record another degraded outcome — that
-    // is the observable proof that the open breaker short-circuited BEFORE
-    // attempting Redis, rather than trying and failing again.
+    // Every lookup that reaches (and fails against) Redis records a degraded
+    // outcome, and — this is the fix under test — so does every lookup that
+    // is short-circuited by an open breaker: an open breaker is a degraded
+    // L2 op, not a free miss. Deterministic (metric-based, not
+    // timing-based): the degraded counter must advance by exactly one per
+    // call in both phases.
     let metrics = Metrics::new();
     let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), metrics.clone())
         .expect("connect (lazy) must succeed even though the address is dead");
     let e = Embedding::new(vec![0.1, 0.2, 0.3]);
 
-    // Drive the breaker open (failure_threshold is 5, see RedisSemanticCache::connect).
+    // Phase 1: drive the breaker open (failure_threshold is 5, see
+    // RedisSemanticCache::connect). Each of these calls actually reaches
+    // (and fails against) the dead address, recording one degraded outcome
+    // apiece.
     for _ in 0..5 {
         assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
     }
     let degraded_at_open = metrics.snapshot().l2_degraded;
-    assert!(
-        degraded_at_open >= 5,
-        "each failed Redis attempt before the breaker opens must record a degraded outcome"
+    assert_eq!(
+        degraded_at_open, 5,
+        "each of the 5 failed Redis attempts before the breaker opens must record a degraded outcome"
     );
 
-    // Once open, further lookups must short-circuit: still None, but the
-    // degraded counter must stop moving because Redis is never contacted.
-    for _ in 0..5 {
+    // Phase 2: once open, further lookups short-circuit BEFORE touching
+    // Redis, but must still count as degraded — exactly one per call.
+    for i in 1..=5u64 {
         assert!(cache.lookup(&e, "complexity|m|t|x").is_none());
+        assert_eq!(
+            metrics.snapshot().l2_degraded,
+            degraded_at_open + i,
+            "an open breaker must record exactly one degraded outcome per short-circuited lookup"
+        );
     }
+
+    // Phase 3: `insert` must apply the same breaker-open accounting.
+    let before_insert = metrics.snapshot().l2_degraded;
+    cache.insert(&e, &result("SIMPLE"), "complexity|m|t|x");
     assert_eq!(
         metrics.snapshot().l2_degraded,
-        degraded_at_open,
-        "an open breaker must short-circuit without attempting Redis (no new degraded records)"
+        before_insert + 1,
+        "insert must also record a degraded outcome when short-circuited by an open breaker"
     );
 }
 

--- a/tests/redis_semantic.rs
+++ b/tests/redis_semantic.rs
@@ -1,10 +1,15 @@
 //! Integration tests for [`llm_d_sc::cache::redis::RedisSemanticCache`].
 //!
+//! The whole suite is gated behind the `redis-semantic` feature: without it the
+//! Redis backend is not compiled, so this file resolves to nothing. Run it with
+//! `cargo test --features redis-semantic --test redis_semantic`.
+//!
 //! The fail-open test runs WITHOUT any Redis server (points at a dead
 //! address) and must always pass under plain `cargo test`. The two
 //! live-Redis tests are `#[ignore]`d (repo convention for external
 //! resources) and require a running Redis Stack at `REDIS_URL`
 //! (see hack/redis-stack.sh).
+#![cfg(feature = "redis-semantic")]
 
 use llm_d_sc::cache::redis::RedisSemanticCache;
 use llm_d_sc::cache::SemanticCache;

--- a/tests/redis_semantic.rs
+++ b/tests/redis_semantic.rs
@@ -50,6 +50,26 @@ fn lookup_is_fail_open_when_redis_is_unreachable() {
 }
 
 #[test]
+fn insert_returns_immediately_even_when_redis_is_down() {
+    // Port 1 is never a Redis; the write-back is async (a background worker
+    // thread owns the actual Redis call), so a burst of inserts against a
+    // dead Redis must return promptly rather than each paying a connection
+    // timeout on the caller's thread.
+    let cache = RedisSemanticCache::connect(&cfg("redis://127.0.0.1:1"), Metrics::new());
+    if let Ok(cache) = cache {
+        let e = Embedding::new(vec![0.1, 0.2, 0.3]);
+        let start = std::time::Instant::now();
+        for _ in 0..100 {
+            cache.insert(&e, &result("SIMPLE"), "complexity|m|t|x");
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(200),
+            "100 inserts must not block on Redis; write-back is async"
+        );
+    }
+}
+
+#[test]
 fn breaker_open_short_circuits_without_calling_redis() {
     // Every lookup that reaches (and fails against) Redis records a degraded
     // outcome, and — this is the fix under test — so does every lookup that


### PR DESCRIPTION
## Summary

Adds a pluggable **semantic cache** to the classifier: a two-tier cache in front of the classification path plus a Redis-backed L2 tier, wired into the production gRPC server and demonstrable through an interactive playground.

- **L1 exact cache** — blake3 versioned-fingerprint lookup that bypasses tokenizer + model forward on a hit.
- **L2 semantic cache** (`redis-semantic` feature) — Redis Stack / RediSearch vector-KNN lookup keyed by prompt embedding, isolated per classifier by an identity tag (classifier id + model/tokenizer/taxonomy revisions), so multiple taxonomies share one Redis without cross-contamination. Fail-open: any Redis error degrades to the compute path, with a consecutive-failure circuit breaker and async, bounded write-back.
- **Metrics** — L2 hit/miss/degraded counters, reconciled with the coalesced-waiter accounting from `v0.2-staging`.
- **Config** — env-driven cache strategy (`exact` / `redis-semantic`) with threshold/TTL/timeout.
- **Playground** (`playground` feature, demo-only binary) — a local web UI over the real classifier + cache, with a classifier selector (complexity / cost / sensitivity), and a semantic **response cache** for OpenAI-compatible chat-completions that forwards misses to an upstream vLLM.

The default build is unchanged: the Redis tier and the playground are behind optional features, and the playground binary is gated by `required-features`.

## Design & plan

- Spec: `docs/superpowers/specs/2026-08-30-semantic-cache-classifier-design.md`
- Plan: `docs/superpowers/plans/2026-08-30-semantic-cache-classifier.md`

## Reconciliation with v0.2-staging

Merged `v0.2-staging` in and resolved the metrics overlap so both survive: the L2 counters and the `cache_coalesced` counter, the `classify_concurrent -> (result, CachePath)` path-based recording, and the split `embed`+`rank` runtime trait (the `metrics_accuracy` test double was ported accordingly).

## Verification

- `cargo build` (default) and `cargo build --features playground` — green
- `cargo clippy` (default and `--features playground`) — clean
- `cargo test` — green (weight-gated and live-Redis tests remain `#[ignore]`d)
- `cargo fmt --check` — clean
- Merges cleanly into `v0.2-staging`.

Signed-off-by: szedan <szedan@redhat.com>
