### PR TITLE
feat: add context completeness specifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 node_modules/
 *.log
 .DS_Store
+.idea/
 
 # Training pipeline outputs: regenerable from training/sdg_llm.py + verify.py.
 # The generated corpora and fine-tuned weights are large and are reproduced by

--- a/docs/known-gaps.md
+++ b/docs/known-gaps.md
@@ -17,7 +17,7 @@ acceptance criterion, every required test ID, and its execution status.
 
 | Gap | Impact | Phase |
 | --- | --- | --- |
-| Abstention is never emitted | `ABSTAIN` is defined in the wire contract so callers can handle it from the start and it never becomes a breaking addition, but the serving path returns `OK` or an explicit error. Deciding when insufficient context warrants abstaining, and proving it, is open work | 0.22 |
+| Insufficient context is not inferred automatically | `ABSTAIN` is emitted when a gateway explicitly marks context as delta-only. The service does not yet infer insufficient context from text, and it has no optional session feature cache to recover it | 0.22 |
 | Scores are similarities, not calibrated probabilities | ranked scores are cosine similarities against labelled anchors. They are comparable within one response, which makes the margin between the top two meaningful, but not across models or taxonomies, and should not be read as statistical confidence | 0.21 |
 | Result cache eviction is FIFO | the cache is bounded (50k entries) so memory is finite, but eviction is insertion-order rather than least-recently-used. FIFO was chosen because it bounds memory at one push and one pop per insert, while LRU needs recency bookkeeping on every hit and a hit is 632 nanoseconds | 0.22 |
 

--- a/proto/classify.proto
+++ b/proto/classify.proto
@@ -15,12 +15,22 @@ enum ClassificationStatus {
   UNAVAILABLE = 3;
 }
 
+// Declares whether `context` contains enough conversation context to classify.
+// This is semantic input supplied by the gateway; it does not transfer session
+// or routing authority to llm-d-sc.
+enum ContextCompleteness {
+  CONTEXT_COMPLETENESS_UNSPECIFIED = 0;
+  FULL = 1;
+  DELTA = 2;
+}
+
 // A classification request from the (dummy) the AI Gateway client.
 message ClassifyRequest {
   string request_id = 1;
   string session_id = 2;
   string context = 3;
   repeated string signals = 4;
+  ContextCompleteness context_completeness = 5;
 }
 
 // One ranked semantic signal: a label and its deterministic similarity score.

--- a/specs/0.22-cache-session/acceptance.md
+++ b/specs/0.22-cache-session/acceptance.md
@@ -1,0 +1,9 @@
+# 0.22 Cache/Session Optimization — Slice 1 Acceptance
+
+- [x] U-048 is RED before implementation and GREEN afterwards.
+- [x] I-046 is RED before implementation and GREEN afterwards.
+- [x] Existing full-context restart coverage remains green.
+- [x] Required impacted suite is green.
+- [x] RED/GREEN command output and worktree state are stored in `evidence/`.
+- [ ] Review confirms no route, endpoint, durable session state, or session-id
+      cache key was introduced.

--- a/specs/0.22-cache-session/design.md
+++ b/specs/0.22-cache-session/design.md
@@ -1,0 +1,16 @@
+# 0.22 Cache/Session Optimization — Slice 1 Design
+
+```text
+Gateway supplies request
+  ├─ FULL or UNSPECIFIED context -> ServiceCore -> cache -> classifier
+  └─ DELTA context               -> ServiceCore -> ABSTAIN
+```
+
+`ContextCompleteness` is a typed field in the core input and an additive enum in
+the protobuf request. The gRPC adapter maps between them. `ServiceCore` enforces
+the rule before it constructs a cache key, so every runtime backend inherits the
+same behavior and raw forwards cannot be accidentally invoked.
+
+An abstention result carries the loaded runtime metadata for provenance, has an
+empty ranking, and is not stored in the exact-result cache. No session id is
+added to the cache key: it is correlation metadata, not semantic input.

--- a/specs/0.22-cache-session/evidence/AC-001/LOCAL-GREEN.md
+++ b/specs/0.22-cache-session/evidence/AC-001/LOCAL-GREEN.md
@@ -1,0 +1,12 @@
+# AC-001 LOCAL-GREEN — delta context abstention
+
+Test: `U-048` (`u048_delta_context_abstains_without_forward_or_cache_access`).
+
+Command:
+
+```text
+cargo test --locked u048_delta_context_abstains_without_forward_or_cache_access --lib
+```
+
+Result: passed. The core returns `ABSTAIN` with an empty ranking and leaves raw
+forward count and exact-cache hit/miss/coalesced counters at zero.

--- a/specs/0.22-cache-session/evidence/AC-001/RED.md
+++ b/specs/0.22-cache-session/evidence/AC-001/RED.md
@@ -1,0 +1,21 @@
+# AC-001 RED — delta context abstention
+
+Test: `U-048` (`u048_delta_context_abstains_without_forward_or_cache_access`).
+
+Command:
+
+```text
+cargo test --locked u048_delta_context_abstains_without_forward_or_cache_access --lib
+```
+
+Expected failure before the short circuit:
+
+```text
+assertion `left == right` failed
+  left: Ok
+ right: Abstain
+```
+
+The test compiled after the additive request/core type scaffolding and failed
+because `ServiceCore` still invoked normal classification for `DELTA` input.
+This is the intended RED condition.

--- a/specs/0.22-cache-session/evidence/AC-002/LOCAL-GREEN.md
+++ b/specs/0.22-cache-session/evidence/AC-002/LOCAL-GREEN.md
@@ -1,0 +1,13 @@
+# AC-002 LOCAL-GREEN — restart plus delta context
+
+Commands:
+
+```text
+cargo test --locked --test restart i046_restart_delta_context_abstains
+cargo test --locked --test restart i045_restart_full_context_recomputes_correctly
+cargo test --locked
+```
+
+Results: `I-046` and the existing full-context restart control (`I-045`) passed.
+The required full suite passed; tests requiring local model artifacts or explicit
+performance runs remained intentionally ignored.

--- a/specs/0.22-cache-session/evidence/AC-002/RED.md
+++ b/specs/0.22-cache-session/evidence/AC-002/RED.md
@@ -1,0 +1,20 @@
+# AC-002 RED — restart plus delta context
+
+Test: `I-046` (`i046_restart_delta_context_abstains`).
+
+Command:
+
+```text
+cargo test --locked --test restart i046_restart_delta_context_abstains
+```
+
+Expected failure before the short circuit:
+
+```text
+assertion `left == right` failed: a delta-only request after cache loss must abstain
+  left: 1
+ right: 2
+```
+
+The fresh server returned protobuf status `OK` (1), rather than `ABSTAIN` (2),
+for a delta-only request. This is the intended RED condition.

--- a/specs/0.22-cache-session/evidence/BENCHMARK.md
+++ b/specs/0.22-cache-session/evidence/BENCHMARK.md
@@ -1,0 +1,34 @@
+# 0.22 Slice 1 — Local Regression Benchmark
+
+## Purpose
+
+Check that adding the context-completeness branch does not regress ordinary
+full-context classification. This is a local regression comparison, not a new
+performance acceptance gate or a claim of attributable improvement.
+
+## Method
+
+- Before revision: `a17834b5c3beb4186e2c1c1d8eb757dce3ed5b85`.
+- After revision: `ea6bd3a652e3b8e39e224e6ce937e498fba51ca5`.
+- Backend: Candle, pinned sensitivity artifact revision
+  `d82ff10d41fcf7d33f90e0597e6621bf1ff94ed4`.
+- Host: Apple M4 Pro; loopback topology.
+- Matrix: cache hit/miss × 32/64/128/256-token target × concurrency 1/4.
+- Each scenario: 20 warmup and 100 measured requests.
+- Before: four valid trials; after: three valid trials. Reported figures are
+  per-scenario medians across trials.
+
+## Result
+
+| Workload | Before p99 range | After p99 range | Finding |
+|---|---:|---:|---|
+| Cache hit | 0.145–0.351 ms | 0.133–0.345 ms | no regression observed |
+| Cache miss | 14.53–151.63 ms | 12.46–91.64 ms | no regression observed |
+
+The after values are lower for most miss scenarios, but these sequential local
+trials do not isolate CPU frequency, thermal state, or background load. They
+must not be interpreted as an implementation-caused speedup.
+
+`DELTA` requests are intentionally absent from this ordinary classification
+matrix: U-048 proves their semantic performance property directly—zero exact
+cache interactions and zero raw model forwards.

--- a/specs/0.22-cache-session/research.md
+++ b/specs/0.22-cache-session/research.md
@@ -1,0 +1,17 @@
+# 0.22 Cache/Session Optimization — Research
+
+## Repository facts
+
+- `ClassificationInput` carries session metadata as passthrough data; semantic
+  classification is currently determined by supplied text.
+- The exact-result cache is versioned by runtime identity and normalized text,
+  and is intentionally disposable.
+- The public protobuf already defines `ABSTAIN`, although production behavior
+  currently returns successful rankings for every non-error request.
+- The 0.1 specification assigns routing and session authority to the AI Gateway.
+
+## Decision
+
+This first slice adds an explicit context-completeness declaration and abstains
+on `DELTA`. It does not add a session cache or make the classifier stateful; an
+isolated follow-up is insufficient context when disposable cache state is absent.

--- a/specs/0.22-cache-session/spec.md
+++ b/specs/0.22-cache-session/spec.md
@@ -1,5 +1,86 @@
-# 0.22 Phase Specification
+# 0.22 Cache/Session Optimization — Slice 1
 
-Versioned result cache, miss coalescing, optional feature/session optimization, complete cache-loss recovery and insufficient-context abstention.
+## Problem
 
-Before implementation, expand this file into the standard SDD fields and map every acceptance criterion to `tests/TEST_MATRIX.md`.
+A follow-up request may be meaningful only with preceding conversation context.
+The exact-result cache is disposable, so after a restart or cache loss the
+classifier must not turn a context-free delta into a confident semantic label.
+
+## Context
+
+Long-running conversations benefit from continuity, but llm-d-sc remains a
+semantic-evidence service. Session continuity, model selection, and routing
+state remain the AI Gateway's responsibility.
+
+## Existing behavior
+
+The API accepts a context string and a session id, but cannot distinguish a
+complete context from a delta-only follow-up. The `ABSTAIN` wire status exists,
+but the serving path never emits it.
+
+## Desired behavior
+
+The request explicitly declares whether its supplied context is complete or a
+delta. A delta-only request returns `ABSTAIN`, with no ranked labels, before
+cache lookup or classifier work. A request whose completeness is absent or full
+keeps the current classification behavior for wire compatibility.
+
+## Non-goals
+
+- Model/endpoint selection, stickiness, tool-loop locking, or routing policy.
+- Durable session storage or cross-replica session coordination.
+- An optional session feature cache; that is a later 0.22 slice.
+- Inferring completeness from session id, prompt text, or cache contents.
+
+## Compatibility
+
+This is an additive protobuf change. `CONTEXT_COMPLETENESS_UNSPECIFIED` retains
+the current behavior so existing clients classify as before. Gateways that send
+delta-only context must set `DELTA` and handle `ABSTAIN`.
+
+## State ownership
+
+The gateway authoritatively owns session history, construction of complete
+context, and the routing decision. llm-d-sc owns only resident runtime state and
+disposable caches. No cache entry may become a routing or session-state source
+of truth.
+
+## Failure behavior
+
+- `DELTA` context -> `ABSTAIN`, empty ranking, no forward and no cache access.
+- complete/unspecified context -> existing classify/error behavior.
+- cache loss + complete context -> recompute; cache loss + delta context ->
+  abstain.
+
+## Security/privacy
+
+The service continues to hash session identifiers in telemetry and does not
+persist raw conversation context beyond the existing bounded, disposable cache.
+
+## Performance and measurement
+
+Delta abstention is a constant-time short circuit. Tests prove it performs zero
+model forwards and does not alter exact-cache counters.
+
+## Rollback
+
+The additive request field can be left unset by clients. Reverting the serving
+logic restores the previous behavior without invalidating existing requests.
+
+## Acceptance criteria
+
+- [ ] AC-001 Explicit `DELTA` context returns `ABSTAIN` with no ranked labels,
+      model forward, or exact-cache interaction (U-048).
+- [ ] AC-002 A fresh server receiving a delta-only follow-up abstains, while a
+      complete context on the same fresh server classifies normally (I-046).
+
+## Negative cases
+
+- N-1 A response contains no model, route, endpoint, or target field (U-010).
+- N-2 Unspecified and full context retain the existing successful behavior.
+- N-3 A session id alone never changes classification behavior.
+
+## Open questions
+
+The representation and invalidation rules for a future optional session feature
+cache are intentionally deferred until this abstention boundary is proven.

--- a/specs/0.22-cache-session/test-plan.md
+++ b/specs/0.22-cache-session/test-plan.md
@@ -1,0 +1,25 @@
+# 0.22 Cache/Session Optimization — Slice 1 Test Plan
+
+## Strategy
+
+| Criterion | Test | Kind | Fails-for-the-right-reason proof |
+|---|---|---|---|
+| AC-001 | U-048 | unit | A DELTA input is currently classified with labels and increments the cache-miss/forward path. |
+| AC-002 | I-046 | integration | A fresh gRPC server currently returns `OK` for a delta-only follow-up. |
+
+U-048 proves the core short circuit: `ABSTAIN`, empty ranking, zero raw forwards,
+and unchanged cache counters. I-046 proves the wire mapping and restart/cache-loss
+boundary. The integration control sends complete context to prove normal
+classification remains available.
+
+## Impact analysis
+
+Expected change surface: protobuf, classification core, gRPC adapter, unit tests,
+and gRPC integration tests. Run `./hack/test-impact` after the files are known,
+then run its Required suite and the focused test commands.
+
+## Mocks
+
+U-048 uses a counting `ClassifierRuntime` test double to prove the core never
+invokes a raw forward. I-046 uses a real tonic server/client and synthetic
+classifier fixture.

--- a/src/bin/classify.rs
+++ b/src/bin/classify.rs
@@ -121,6 +121,7 @@ fn main() {
             text: text.clone(),
             requested_signals: vec![definition.signal.clone()],
             session_metadata: Default::default(),
+            context_completeness: Default::default(),
         });
         let ms = t0.elapsed().as_secs_f64() * 1000.0;
         match result {

--- a/src/bin/gateway-probe.rs
+++ b/src/bin/gateway-probe.rs
@@ -54,6 +54,7 @@ fn main() {
         // serves, and asserting one couples the tool to a single deployment.
         // An empty list means "no constraint" and the server returns its signal.
         signals: Vec::new(),
+        context_completeness: Default::default(),
     };
 
     // Warm the connection and the model so the first sample does not carry

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -60,6 +60,23 @@ pub struct ClassificationInput {
     pub text: String,
     pub requested_signals: Vec<String>,
     pub session_metadata: HashMap<String, String>,
+    pub context_completeness: ContextCompleteness,
+}
+
+/// Whether the caller supplied complete semantic context or only a follow-up.
+///
+/// The gateway is authoritative for assembling conversation context. This
+/// marker lets the classifier decline a delta-only request safely without
+/// retaining durable session state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContextCompleteness {
+    /// Legacy callers do not declare completeness; preserve existing behavior.
+    #[default]
+    Unspecified,
+    /// The supplied text contains complete context and can be classified.
+    Full,
+    /// The supplied text is only a follow-up and needs prior context.
+    Delta,
 }
 
 /// One ranked semantic signal: an id and its deterministic similarity score.
@@ -188,6 +205,22 @@ impl RuntimeMetadata {
     }
 }
 
+/// Build a provenance-preserving abstention without invoking a runtime backend.
+///
+/// A delta-only follow-up is not sufficient semantic input after disposable
+/// cache/session state is lost. The gateway must supply full context before the
+/// classifier can produce ranked evidence.
+fn insufficient_context_abstention(meta: RuntimeMetadata) -> ClassificationResult {
+    ClassificationResult {
+        classifier_id: meta.classifier_id,
+        model_revision: meta.model_revision,
+        tokenizer_revision: meta.tokenizer_revision,
+        taxonomy_revision: meta.taxonomy_revision,
+        status: ClassifyStatus::Abstain,
+        ranked: Vec::new(),
+    }
+}
+
 /// A generic classification service core shared by EVERY backend.
 ///
 /// Wraps any [`ClassifierRuntime`] backend (`R`) and centralizes the exact-result
@@ -262,6 +295,13 @@ where
     /// versioned fingerprint, and the hit/miss/total/queue metrics are recorded
     /// here so EVERY backend inherits them.
     fn classify(&self, input: ClassificationInput) -> Result<ClassificationResult, ClassifyError> {
+        // A delta-only follow-up cannot be safely classified in isolation. This
+        // check deliberately precedes normalization, cache lookup, and raw
+        // runtime work: an exact-result/session cache is disposable acceleration,
+        // never authoritative conversation state.
+        if input.context_completeness == ContextCompleteness::Delta {
+            return Ok(insufficient_context_abstention(self.runtime.metadata()));
+        }
         let normalized = input.text.trim().to_string();
         // Key on the identity the WRAPPED RUNTIME reports, not on module
         // constants. Keying on constants meant every backend shared one
@@ -283,6 +323,7 @@ where
                 text: normalized,
                 requested_signals: input.requested_signals,
                 session_metadata: input.session_metadata,
+                context_completeness: input.context_completeness,
             };
             move || runtime.classify(input)
         };
@@ -606,6 +647,7 @@ pub fn load_and_warm_modelcar<P: AsRef<std::path::Path>>(
         text: WARMUP_INPUT.to_string(),
         requested_signals: vec!["sensitivity".to_string()],
         session_metadata: HashMap::new(),
+        context_completeness: ContextCompleteness::Full,
     };
     classifier
         .classify(warmup_input)
@@ -792,6 +834,7 @@ mod tests {
             text: "this is a golden sensitivity input".to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: HashMap::from([("session_id".to_string(), "sess-0001".to_string())]),
+            context_completeness: ContextCompleteness::Full,
         };
         let result = service.classify(input).expect("golden input must classify");
         assert_eq!(result.status, ClassifyStatus::Ok);
@@ -825,12 +868,58 @@ mod tests {
             text: "this is a golden sensitivity input".to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: HashMap::new(),
+            context_completeness: ContextCompleteness::Full,
         };
         let first = core.classify(input.clone()).expect("first classify");
         let second = core.classify(input).expect("second classify");
         assert_eq!(
             first, second,
             "identical inputs must produce identical results"
+        );
+    }
+
+    /// U-048: a delta-only follow-up must not be classified as standalone
+    /// context. It abstains before interacting with the exact-result cache or
+    /// invoking the raw classifier.
+    #[test]
+    fn u048_delta_context_abstains_without_forward_or_cache_access() {
+        let metrics = Metrics::new();
+        let core =
+            ServiceCore::with_metrics(ClassifyService::from_synthetic_fixtures(), metrics.clone());
+        let result = core
+            .classify(ClassificationInput {
+                text: "do that again".to_string(),
+                requested_signals: vec!["sensitivity".to_string()],
+                session_metadata: HashMap::from([(
+                    "session_id".to_string(),
+                    "sess-delta".to_string(),
+                )]),
+                context_completeness: ContextCompleteness::Delta,
+            })
+            .expect("delta context must return a typed abstention");
+
+        assert_eq!(result.status, ClassifyStatus::Abstain);
+        assert!(
+            result.ranked.is_empty(),
+            "abstention must not fabricate a label"
+        );
+        assert_eq!(
+            core.forward_count(),
+            0,
+            "delta context must not invoke a raw forward"
+        );
+        let snapshot = metrics.snapshot();
+        assert_eq!(
+            snapshot.cache_hits, 0,
+            "delta context must not read the cache"
+        );
+        assert_eq!(
+            snapshot.cache_misses, 0,
+            "delta context must not populate the cache"
+        );
+        assert_eq!(
+            snapshot.cache_coalesced, 0,
+            "delta context must not join a cache flight"
         );
     }
 
@@ -853,6 +942,7 @@ mod tests {
             text: "this is a golden sensitivity input".to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: HashMap::new(),
+            context_completeness: ContextCompleteness::Full,
         };
         let result = classifier
             .classify(input)
@@ -892,6 +982,7 @@ mod tests {
             text: WARMUP_INPUT.to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: HashMap::new(),
+            context_completeness: ContextCompleteness::Full,
         };
 
         // Miss: exactly one tokenizer call and one model forward.
@@ -928,6 +1019,7 @@ mod tests {
             text: "a distinct sensitivity context for a fresh miss".to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: HashMap::new(),
+            context_completeness: ContextCompleteness::Full,
         };
         core.classify(other).expect("distinct input must classify");
         assert_eq!(

--- a/src/dummy_gateway.rs
+++ b/src/dummy_gateway.rs
@@ -83,6 +83,7 @@ impl DummyGateway {
             session_id: req.session_id.clone(),
             context: req.context.clone(),
             signals: req.signals.clone(),
+            context_completeness: Default::default(),
         };
 
         let start = std::time::Instant::now();

--- a/src/grpc/classify.rs
+++ b/src/grpc/classify.rs
@@ -183,6 +183,19 @@ where
             text: req.context,
             requested_signals: req.signals,
             session_metadata: HashMap::from([("session_id".to_string(), req.session_id)]),
+            context_completeness: match generated::ContextCompleteness::try_from(
+                req.context_completeness,
+            )
+            .unwrap_or(generated::ContextCompleteness::Unspecified)
+            {
+                generated::ContextCompleteness::Full => crate::classify::ContextCompleteness::Full,
+                generated::ContextCompleteness::Delta => {
+                    crate::classify::ContextCompleteness::Delta
+                }
+                generated::ContextCompleteness::Unspecified => {
+                    crate::classify::ContextCompleteness::Unspecified
+                }
+            },
         };
         // AC-008 / ADR-0002: hand the job to the dedicated inference executor
         // over a BOUNDED handoff. The model forward does NOT run on this Tokio

--- a/tests/executor_pool.rs
+++ b/tests/executor_pool.rs
@@ -87,6 +87,7 @@ fn i090_executor_workers_run_forwards_in_parallel() {
                     text: format!("job {i}"),
                     requested_signals: vec!["sensitivity".into()],
                     session_metadata: Default::default(),
+                    context_completeness: Default::default(),
                 })
                 .expect("bound of 32 must admit 4 jobs")
         })
@@ -137,6 +138,7 @@ fn i091_single_worker_executor_is_observably_serial() {
                     text: format!("job {i}"),
                     requested_signals: vec!["sensitivity".into()],
                     session_metadata: Default::default(),
+                    context_completeness: Default::default(),
                 })
                 .expect("must admit")
         })

--- a/tests/floor.rs
+++ b/tests/floor.rs
@@ -30,6 +30,7 @@ fn inference_floor_by_length() {
             text: text.clone(),
             requested_signals: Vec::new(),
             session_metadata: HashMap::new(),
+            context_completeness: Default::default(),
         };
         for _ in 0..20 {
             let _ = clf.classify(inp.clone());

--- a/tests/floor_conc.rs
+++ b/tests/floor_conc.rs
@@ -27,6 +27,7 @@ fn concurrency_scaling() {
         text: text.clone(),
         requested_signals: Vec::new(),
         session_metadata: HashMap::new(),
+        context_completeness: Default::default(),
     };
     for _ in 0..20 {
         let _ = clf.classify(mk());
@@ -53,6 +54,7 @@ fn concurrency_scaling() {
                             text: t.clone(),
                             requested_signals: Vec::new(),
                             session_metadata: HashMap::new(),
+                            context_completeness: Default::default(),
                         };
                         let s = Instant::now();
                         c.classify(i).expect("classify must succeed");

--- a/tests/grpc.rs
+++ b/tests/grpc.rs
@@ -30,6 +30,7 @@ fn fixture_request(request_id: &str, session_id: &str) -> ClassifyRequest {
         session_id: session_id.to_string(),
         context: "this is a golden sensitivity input".to_string(),
         signals: Vec::new(),
+        context_completeness: generated::ContextCompleteness::Full as i32,
     }
 }
 

--- a/tests/integration_sweep.rs
+++ b/tests/integration_sweep.rs
@@ -30,6 +30,7 @@ fn input(text: &str) -> ClassificationInput {
         text: text.to_string(),
         requested_signals: Vec::new(),
         session_metadata: Default::default(),
+        context_completeness: Default::default(),
     }
 }
 

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -97,6 +97,7 @@ fn i080_latency_decomposition_metrics_visible() {
             session_id: "sess-0001".to_string(),
             context: "unique sensitivity context with distinct tokens".to_string(),
             signals: Vec::new(),
+            context_completeness: Default::default(),
         })
         .expect("cache-miss classify must succeed");
     assert!(!miss.ranked.is_empty(), "miss must return ranked signals");
@@ -112,6 +113,7 @@ fn i080_latency_decomposition_metrics_visible() {
             session_id: "sess-0001".to_string(),
             context: "unique sensitivity context with distinct tokens".to_string(),
             signals: Vec::new(),
+            context_completeness: Default::default(),
         })
         .expect("cache-hit classify must succeed");
     assert!(!hit.ranked.is_empty(), "hit must return ranked signals");

--- a/tests/metrics_accuracy.rs
+++ b/tests/metrics_accuracy.rs
@@ -44,6 +44,7 @@ fn input(text: &str) -> ClassificationInput {
         text: text.to_string(),
         requested_signals: vec!["complexity".to_string()],
         session_metadata: Default::default(),
+        context_completeness: Default::default(),
     }
 }
 

--- a/tests/modelcar.rs
+++ b/tests/modelcar.rs
@@ -152,6 +152,7 @@ fn i063_service_starts_from_artifact_with_hf_egress_disabled() {
             text: "What is the capital of Norway?".to_string(),
             requested_signals: vec!["sensitivity".to_string()],
             session_metadata: Default::default(),
+            context_completeness: Default::default(),
         })
         .expect("offline classification must succeed");
     assert!(!result.ranked.is_empty());

--- a/tests/perf_concurrency.rs
+++ b/tests/perf_concurrency.rs
@@ -39,6 +39,7 @@ fn input(text: &str) -> ClassificationInput {
         text: text.to_string(),
         requested_signals: Vec::new(),
         session_metadata: Default::default(),
+        context_completeness: Default::default(),
     }
 }
 
@@ -243,6 +244,7 @@ fn p002_grpc_localhost_cache_hit() {
         session_id: "sess-p002".to_string(),
         context: "a stable prompt served repeatedly from the cache".to_string(),
         signals: Vec::new(),
+        context_completeness: Default::default(),
     };
 
     let t0 = Instant::now();

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -77,6 +77,7 @@ fn request(i: usize) -> generated::ClassifyRequest {
         session_id: "sess-sat".to_string(),
         context: format!("unique saturation context {i}"),
         signals: vec!["sensitivity".to_string()],
+        context_completeness: generated::ContextCompleteness::Full as i32,
     }
 }
 
@@ -182,6 +183,7 @@ async fn i035_saturation_rejects_rather_than_runaway_queueing() {
             session_id: "sess-recovery".to_string(),
             context: "post-saturation recovery request".to_string(),
             signals: vec!["sensitivity".to_string()],
+            context_completeness: Default::default(),
         })
         .await
         .expect("service must recover after load stops");

--- a/tests/realserve.rs
+++ b/tests/realserve.rs
@@ -49,6 +49,7 @@ fn real_served_path_classifies_from_actual_embedding() {
             session_id: "sess-real".to_string(),
             context: WARMUP_INPUT.to_string(),
             signals: Vec::new(),
+            context_completeness: Default::default(),
         })
         .expect("real classify must succeed");
 

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -24,6 +24,7 @@ fn full_context_request() -> ClassifyRequest {
         session_id: "sess-045".to_string(),
         context: "this is a golden sensitivity input".to_string(),
         signals: Vec::new(),
+        context_completeness: llm_d_sc::grpc::classify::generated::ContextCompleteness::Full as i32,
     }
 }
 
@@ -91,5 +92,60 @@ fn i045_restart_full_context_recomputes_correctly() {
     assert_eq!(
         before.ranked, after.ranked,
         "AC-013: restart + complete context must recompute an equivalent result"
+    );
+}
+
+/// I-046: a restarted instance has no disposable cache or session feature
+/// state. A delta-only follow-up must therefore abstain, while full context can
+/// still be classified normally.
+#[test]
+fn i046_restart_delta_context_abstains() {
+    // Establish that the original instance could classify full context, then
+    // discard it together with its disposable caches as a restart would.
+    let server_a = ClassifyServer::bind("127.0.0.1:0").expect("pre-restart server must bind");
+    let mut client_a = llm_d_sc::grpc::classify::ClassifyClient::connect(server_a.local_addr())
+        .expect("pre-restart client must connect");
+    let full = client_a
+        .classify(full_context_request())
+        .expect("pre-restart full context must classify");
+    assert_eq!(
+        full.status,
+        llm_d_sc::grpc::classify::generated::ClassificationStatus::Ok as i32
+    );
+    drop(client_a);
+    drop(server_a);
+
+    let server_b = ClassifyServer::bind("127.0.0.1:0").expect("post-restart server must bind");
+    let mut client_b = llm_d_sc::grpc::classify::ClassifyClient::connect(server_b.local_addr())
+        .expect("post-restart client must connect");
+
+    let response = client_b
+        .classify(ClassifyRequest {
+            request_id: "req-046".to_string(),
+            session_id: "sess-046".to_string(),
+            context: "do that again".to_string(),
+            signals: Vec::new(),
+            context_completeness: llm_d_sc::grpc::classify::generated::ContextCompleteness::Delta
+                as i32,
+        })
+        .expect("delta request must receive a typed response");
+
+    assert_eq!(
+        response.status,
+        llm_d_sc::grpc::classify::generated::ClassificationStatus::Abstain as i32,
+        "a delta-only request after cache loss must abstain"
+    );
+    assert!(
+        response.ranked.is_empty(),
+        "abstention must not contain a label"
+    );
+    let snapshot = server_b.metrics_snapshot();
+    assert_eq!(
+        snapshot.cache_hits, 0,
+        "delta request must not read the cache"
+    );
+    assert_eq!(
+        snapshot.cache_misses, 0,
+        "delta request must not run a forward"
     );
 }

--- a/tests/runtime_metadata.rs
+++ b/tests/runtime_metadata.rs
@@ -134,6 +134,7 @@ fn i095_grpc_validates_requested_signal_against_the_loaded_runtime() {
         session_id: "sess".into(),
         context: "What is the capital of Peru?".into(),
         signals,
+        context_completeness: Default::default(),
     };
 
     // The signal this instance actually serves is accepted.

--- a/tests/taxonomy_served.rs
+++ b/tests/taxonomy_served.rs
@@ -26,6 +26,7 @@ fn request(id: &str, text: &str) -> ClassifyRequest {
         session_id: "sess-taxonomy".into(),
         context: text.into(),
         signals: Vec::new(),
+        context_completeness: Default::default(),
     }
 }
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -67,6 +67,7 @@ fn i085_trace_capture_has_ids_hashes_no_raw_prompt() {
             session_id: "sess-trace-secret".to_string(),
             context: "a TRACE secret prompt that must stay out of traces".to_string(),
             signals: Vec::new(),
+            context_completeness: Default::default(),
         })
         .expect("classify must succeed");
 


### PR DESCRIPTION
first stab at implementing part of 0.22, according to the internal rules.
Returns ABSTAIN if context_completeness == DELTA (we don't have any machinery in place yet).

- created spec
- first part of implementation, with tests 
- BENCHMARK.md to show that there are no regression

details in spec.md. Excerpt:

----

## Problem

A follow-up request may be meaningful only with preceding conversation context.
The exact-result cache is disposable, so after a restart or cache loss the
classifier must not turn a context-free delta into a confident semantic label.

## Context

Long-running conversations benefit from continuity, but llm-d-sc remains a
semantic-evidence service. Session continuity, model selection, and routing
state remain the AI Gateway's responsibility.

## Existing behavior

The API accepts a context string and a session id, but cannot distinguish a
complete context from a delta-only follow-up. The `ABSTAIN` wire status exists,
but the serving path never emits it.

## Desired behavior

The request explicitly declares whether its supplied context is complete or a
delta. A delta-only request returns `ABSTAIN`, with no ranked labels, before
cache lookup or classifier work. A request whose completeness is absent or full
keeps the current classification behavior for wire compatibility.

## Non-goals

- Model/endpoint selection, stickiness, tool-loop locking, or routing policy.
- Durable session storage or cross-replica session coordination.
- An optional session feature cache; that is a later 0.22 slice.
- Inferring completeness from session id, prompt text, or cache contents.

## Compatibility

This is an additive protobuf change. `CONTEXT_COMPLETENESS_UNSPECIFIED` retains
the current behavior so existing clients classify as before. Gateways that send
delta-only context must set `DELTA` and handle `ABSTAIN`.




