### PR TITLE
fix: include architecture config in ModelCar digest

### DIFF
--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -17,6 +17,18 @@ The project remains intentionally pre-1.0. Phase names describe maturity; versio
 
 ## 0.1 MVP
 
+### Unreleased fixes
+
+- ModelCar content digests now include the BERT architecture `config.json`,
+  alongside weights, tokenizer, and pooling configuration. All existing
+  ModelCar content digests change, even when artifact bytes are unchanged;
+  regenerate any recorded digest expectations. Cache identities derived from
+  these digests also change. Mounts missing `config.json` fail readiness checks.
+  Hugging Face revision pins and OCI image digests are unaffected. Fixes
+  [#4](https://github.com/llm-d-incubation/llm-d-semantic-classifier/issues/4).
+
+### Scope
+
 Prove the shape of the service:
 - Rust server and protobuf contract;
 - `ClassifierRuntime` abstraction;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,7 @@ use crate::tokenizer::Tokenizer;
 /// can validate the ModelCar layout before loading (AC-002/AC-003).
 pub const MODELCAR_REQUIRED_FILES: &[&str] = &[
     "model.safetensors",
+    "config.json",
     "tokenizer.json",
     "1_Pooling/config.json",
 ];
@@ -266,7 +267,7 @@ mod tests {
     fn i064_incomplete_modelcar_fails_readiness() {
         // I-064 (AC-003): an incomplete/corrupt ModelCar must fail readiness.
         // The ModelCar manifest (classifier-manifest.json) requires the files
-        // `/models/model.safetensors`, `/models/tokenizer.json`, and
+        // `/models/model.safetensors`, `/models/config.json`, `/models/tokenizer.json`, and
         // `/models/1_Pooling/config.json` to be present and readable. A model
         // directory that exists but is missing these required files must keep
         // the runtime NOT ready.

--- a/tests/fixtures/modelcar/classifier-manifest.json
+++ b/tests/fixtures/modelcar/classifier-manifest.json
@@ -12,6 +12,7 @@
   },
   "model": {
     "weights": "/models/model.safetensors",
+    "config": "/models/config.json",
     "tokenizer": "/models/tokenizer.json",
     "pooling_config": "/models/1_Pooling/config.json"
   },

--- a/tests/modelcar.rs
+++ b/tests/modelcar.rs
@@ -4,7 +4,8 @@
 //! Hugging Face fetch, must reject an incomplete mount, and must be able to tie
 //! a served result to the exact bytes it loaded.
 //!
-//! Requires fetched weights; run with `cargo test --test modelcar -- --ignored`.
+//! Ignored tests require fetched weights; run with
+//! `cargo test --test modelcar -- --ignored`.
 
 use llm_d_sc::runtime::{modelcar_digest, Readiness, Runtime, MODELCAR_REQUIRED_FILES};
 
@@ -13,6 +14,52 @@ fn model_dir(name: &str) -> std::path::PathBuf {
         .join("artifacts")
         .join("models")
         .join(name)
+}
+
+/// I-062: changing only the architecture config must change artifact identity.
+#[test]
+fn i062_architecture_config_changes_digest() {
+    let dir = std::env::temp_dir().join(format!("llm-d-sc-i062-config-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("1_Pooling")).unwrap();
+    // Digesting uses real file bytes but does not require a loadable model.
+    for file in [
+        "model.safetensors",
+        "tokenizer.json",
+        "1_Pooling/config.json",
+    ] {
+        std::fs::write(dir.join(file), b"unchanged").unwrap();
+    }
+    let config = dir.join("config.json");
+    std::fs::write(&config, br#"{"hidden_size":384}"#).unwrap();
+    let before = modelcar_digest(&dir, MODELCAR_REQUIRED_FILES).unwrap();
+    assert_eq!(
+        before,
+        modelcar_digest(&dir, MODELCAR_REQUIRED_FILES).unwrap()
+    );
+
+    std::fs::write(&config, br#"{"hidden_size":768}"#).unwrap();
+    let after = modelcar_digest(&dir, MODELCAR_REQUIRED_FILES).unwrap();
+    std::fs::remove_dir_all(&dir).unwrap();
+    assert_ne!(before, after, "config.json must contribute to the digest");
+}
+
+/// I-060: a mount missing only the architecture config must fail readiness.
+#[test]
+fn i060_missing_architecture_config_fails_readiness() {
+    let dir = std::env::temp_dir().join(format!("llm-d-sc-i060-config-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("1_Pooling")).unwrap();
+    for file in MODELCAR_REQUIRED_FILES {
+        if *file != "config.json" {
+            std::fs::write(dir.join(file), b"present").unwrap();
+        }
+    }
+    let mut runtime = Runtime::new();
+    let result = runtime.warmup_modelcar(&dir, MODELCAR_REQUIRED_FILES);
+    std::fs::remove_dir_all(&dir).unwrap();
+    let error = result.expect_err("a ModelCar without config.json must fail warmup");
+    assert!(error.contains("config.json"), "{error}");
+    assert_eq!(runtime.readiness(), Readiness::NotReady);
+    assert_eq!(runtime.artifact_digest(), None);
 }
 
 /// I-060: the ModelCar must contain every required file, and a mount missing any
@@ -34,7 +81,7 @@ fn i060_modelcar_contains_required_files() {
 
     // Each required file, removed individually, must break warmup. Asserting
     // only on a wholly empty directory would pass even if the check looked at
-    // just one of the three.
+    // just one of the required files.
     for omit in MODELCAR_REQUIRED_FILES {
         let partial =
             std::env::temp_dir().join(format!("llm-d-sc-i060-{}", omit.replace('/', "_")));


### PR DESCRIPTION
Changing a ModelCar's BERT `config.json` previously left its content digest unchanged, even though the runtime reads that file when loading the model. Include it in `MODELCAR_REQUIRED_FILES` so architecture changes affect artifact identity and missing configurations fail readiness validation.

Add two offline regression tests under I-060 and I-062, update the ModelCar manifest, and document the compatibility impact in the version notes. All existing ModelCar content digests change; recorded expectations must be regenerated, and digest-derived cache identities change as well. Hugging Face revision pins and OCI image digests are unaffected.

Validation:
- Before the fix, both new tests failed: changing only `config.json` produced the same digest, and a mount missing it passed warmup.
- After the fix, `./hack/verify` passed (format, Clippy with warnings denied, locked build, and 84 passing tests).
- Model-dependent ignored tests were not run. The regression tests exercise actual file hashing and readiness checks without downloading weights.

This contribution was prepared with AI assistance.

Fixes #4.
