### PR TITLE
fix: include model revision and artifact digest in cache identity

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -70,12 +70,36 @@ impl CacheKey {
         taxonomy_revision: impl Into<String>,
         normalized_text: &str,
     ) -> Self {
+        Self::new_with_artifact_digest(
+            classifier_id,
+            model_revision,
+            tokenizer_revision,
+            taxonomy_revision,
+            normalized_text,
+            None,
+        )
+    }
+
+    /// Build a key with both the declared revision and the loaded artifact's
+    /// content digest. The optional digest is a separate length-prefixed field;
+    /// it never replaces the model revision. `None` preserves `new`'s identity.
+    pub fn new_with_artifact_digest(
+        classifier_id: impl Into<String>,
+        model_revision: impl Into<String>,
+        tokenizer_revision: impl Into<String>,
+        taxonomy_revision: impl Into<String>,
+        normalized_text: &str,
+        artifact_digest: Option<&str>,
+    ) -> Self {
         let mut hasher = blake3::Hasher::new();
         update_field(&mut hasher, &classifier_id.into());
         update_field(&mut hasher, &model_revision.into());
         update_field(&mut hasher, &tokenizer_revision.into());
         update_field(&mut hasher, &taxonomy_revision.into());
         update_field(&mut hasher, normalized_text);
+        if let Some(digest) = artifact_digest {
+            update_field(&mut hasher, digest);
+        }
         CacheKey {
             fingerprint: hasher.finalize().into(),
         }

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -176,14 +176,13 @@ impl RuntimeMetadata {
     /// The identity components used to key the result cache. A change in ANY of
     /// them must produce a different key, so a stale classification can never be
     /// served across a revision or artifact change.
-    pub fn cache_identity(&self) -> (&str, &str, &str, &str) {
+    pub fn cache_identity(&self) -> (&str, &str, &str, &str, Option<&str>) {
         (
             &self.classifier_id,
-            self.artifact_digest
-                .as_deref()
-                .unwrap_or(&self.model_revision),
+            &self.model_revision,
             &self.tokenizer_revision,
             &self.taxonomy_revision,
+            self.artifact_digest.as_deref(),
         )
     }
 }
@@ -268,13 +267,15 @@ where
         // namespace: two taxonomies in one process would have collided, and a
         // revision change would have served the previous revision's answers.
         let meta = self.runtime.metadata();
-        let (classifier_id, model_rev, tokenizer_rev, taxonomy_rev) = meta.cache_identity();
-        let key = CacheKey::new(
+        let (classifier_id, model_rev, tokenizer_rev, taxonomy_rev, artifact_digest) =
+            meta.cache_identity();
+        let key = CacheKey::new_with_artifact_digest(
             classifier_id,
             model_rev,
             tokenizer_rev,
             taxonomy_rev,
             &normalized,
+            artifact_digest,
         );
         let metrics = self.metrics.clone();
         let forward = {

--- a/tests/runtime_metadata.rs
+++ b/tests/runtime_metadata.rs
@@ -7,10 +7,11 @@
 //! test happened to pass the one string the hardcoded check expected. These
 //! tests fail if any of that is reintroduced.
 //!
-//! Requires fetched weights; run with `cargo test --test runtime_metadata -- --ignored`.
+//! Ignored tests require fetched weights; run with
+//! `cargo test --test runtime_metadata -- --ignored`.
 
 use llm_d_sc::cache::CacheKey;
-use llm_d_sc::classify::{CandleClassifier, ClassifierRuntime, ServiceCore};
+use llm_d_sc::classify::{CandleClassifier, ClassifierRuntime, RuntimeMetadata, ServiceCore};
 use llm_d_sc::taxonomy::ClassifierDefinition;
 
 fn classifier(name: &str) -> CandleClassifier {
@@ -77,36 +78,86 @@ fn u111_different_classifiers_produce_different_cache_keys() {
     let b = classifier("sensitivity").metadata();
     assert_ne!(a.cache_identity(), b.cache_identity());
 
-    let (a1, a2, a3, a4) = a.cache_identity();
-    let (b1, b2, b3, b4) = b.cache_identity();
+    let (a1, a2, a3, a4, a5) = a.cache_identity();
+    let (b1, b2, b3, b4, b5) = b.cache_identity();
     let text = "an identical prompt sent to both classifiers";
     assert_ne!(
-        CacheKey::new(a1, a2, a3, a4, text),
-        CacheKey::new(b1, b2, b3, b4, text),
+        CacheKey::new_with_artifact_digest(a1, a2, a3, a4, text, a5),
+        CacheKey::new_with_artifact_digest(b1, b2, b3, b4, text, b5),
         "the same text under two taxonomies must not collide in the cache"
     );
 }
 
 /// U-112: a change in ANY identity component changes the key.
 #[test]
-#[ignore]
 fn u112_every_identity_component_participates_in_the_cache_key() {
-    let m = classifier("complexity").metadata();
-    let (c, mo, tk, tx) = m.cache_identity();
-    let text = "a stable prompt";
-    let base = CacheKey::new(c, mo, tk, tx, text);
-
-    for (label, key) in [
-        ("classifier_id", CacheKey::new("other", mo, tk, tx, text)),
-        ("model/digest", CacheKey::new(c, "other", tk, tx, text)),
-        (
+    let original = RuntimeMetadata {
+        classifier_id: "complexity".into(),
+        signal: "complexity".into(),
+        model_revision: "model-rev".into(),
+        tokenizer_revision: "tokenizer-rev".into(),
+        taxonomy_revision: "taxonomy-rev".into(),
+        artifact_digest: Some("blake3:artifact".into()),
+    };
+    let key = |m: &RuntimeMetadata| {
+        let (c, mo, tk, tx, digest) = m.cache_identity();
+        CacheKey::new_with_artifact_digest(c, mo, tk, tx, "a stable prompt", digest)
+    };
+    // Exercise metadata before key construction: substituting the digest for
+    // the revision must not hide revision changes from this test.
+    for digest in [Some("blake3:artifact".to_string()), None] {
+        let mut base = original.clone();
+        base.artifact_digest = digest;
+        assert_eq!(key(&base), key(&base.clone()));
+        for field in [
+            "classifier_id",
+            "model_revision",
             "tokenizer_revision",
-            CacheKey::new(c, mo, "other", tx, text),
-        ),
-        ("taxonomy_revision", CacheKey::new(c, mo, tk, "other", text)),
-    ] {
-        assert_ne!(base, key, "changing {label} must change the cache key");
+            "taxonomy_revision",
+            "artifact_digest",
+        ] {
+            let mut changed = base.clone();
+            match field {
+                "classifier_id" => changed.classifier_id = "other".into(),
+                "model_revision" => changed.model_revision = "other".into(),
+                "tokenizer_revision" => changed.tokenizer_revision = "other".into(),
+                "taxonomy_revision" => changed.taxonomy_revision = "other".into(),
+                "artifact_digest" => changed.artifact_digest = Some("blake3:other".into()),
+                _ => unreachable!(),
+            }
+            assert_ne!(
+                key(&base),
+                key(&changed),
+                "changing {field} must change the cache key"
+            );
+        }
     }
+}
+
+/// U-112: optional digests and adjacent variable-length fields cannot alias.
+#[test]
+fn u112_digest_presence_and_field_boundaries_are_distinct() {
+    let key = |revision, text, digest| {
+        CacheKey::new_with_artifact_digest("c", revision, "t", "x", text, digest)
+    };
+    assert_eq!(
+        CacheKey::new("c", "revision", "t", "x", "prompt"),
+        key("revision", "prompt", None)
+    );
+    for digest in ["", "revision"] {
+        assert_ne!(
+            key("revision", "prompt", None),
+            key("revision", "prompt", Some(digest))
+        );
+    }
+    assert_ne!(
+        key("ab", "prompt", Some("c")),
+        key("a", "prompt", Some("bc"))
+    );
+    assert_ne!(
+        key("revision", "ab", Some("c")),
+        key("revision", "a", Some("bc"))
+    );
 }
 
 /// U-113: ServiceCore reports the WRAPPED backend's identity, not its own.


### PR DESCRIPTION
When an artifact digest was present, `RuntimeMetadata::cache_identity()` discarded the declared model revision. Identical artifact bytes under different revisions therefore shared a cache namespace, which would become unsafe when revision swaps are supported.

Keep the revision and optional digest as separate identity components and pass both through `ServiceCore` to the length-prefixed BLAKE3 cache key. `CacheKey::new` remains available for callers without an artifact digest and preserves their existing keys. `cache_identity()` now returns a five-element tuple, with the optional digest last; artifact-backed cache keys change.

Strengthen U-112 to mutate runtime metadata before constructing keys, covering each revision and the digest independently, both with and without an artifact. It now runs without model downloads. The prior test mutated the already-substituted model/digest component, so it could not detect the lost model revision. Add coverage for absent versus empty digests and ambiguous concatenations; retain the existing classifier-namespace assertion.

Validation:
- RED: `cargo test --locked --test runtime_metadata u112` failed because changing only `model_revision` produced the same cache key.
- GREEN: `./hack/verify` passed, including formatting, Clippy with warnings denied, the locked build, and 84 passing tests.
- Model-dependent ignored tests were not run.

Prepared with AI assistance. This change is based directly on main and does not depend on PR #25.

Fixes #3.
